### PR TITLE
Allow skipping internet dependent tests, fix npm dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ the code Django includes for this purpose: `SECRET_KEY=$(python -c "from django.
 pycodestyle --exclude=migrations,settings.py,venv --max-line-length=100 .
 DJANGO_DEV=1 pytest 
 ```
-
+To skip tests which require internet connection:
+```
+DJANGO_DEV=1 pytest  -m "not webtest"
+```
 ## Data import
 
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = vulnerablecode.settings
+markers =
+    webtest: marker for tests which require internet connection.

--- a/vulnerabilities/data_dump.py
+++ b/vulnerabilities/data_dump.py
@@ -185,6 +185,7 @@ def npm_dump(extract_data):
             for version in data['fixed_versions']:
                 package_fixed = Package.objects.create(
                     name=package_name,
+                    type='npm',
                     version=version
                 )
                 ResolvedPackage.objects.create(

--- a/vulnerabilities/tests/test_npm.py
+++ b/vulnerabilities/tests/test_npm.py
@@ -23,7 +23,7 @@
 
 import os
 import json
-
+import pytest
 
 from vulnerabilities.scraper.npm import extract_data
 from vulnerabilities.scraper.npm import get_all_versions
@@ -32,6 +32,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, 'test_data/')
 
 
+@pytest.mark.webtest
 def test_get_all_versions():
     x = get_all_versions('electron')
     expected = ['0.1.2', '2.0.0', '3.0.0',
@@ -39,6 +40,7 @@ def test_get_all_versions():
     assert set(expected) <= set(x)
 
 
+@pytest.mark.webtest
 def test_extract_data():
     with open(os.path.join(TEST_DATA, 'npm_test.json')) as f:
         test_data = json.load(f)

--- a/vulnerabilities/tests/test_rust.py
+++ b/vulnerabilities/tests/test_rust.py
@@ -21,12 +21,14 @@
 #  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 
+import pytest
 from vulnerabilities.scraper.rust import rust_crate_advisories
 from vulnerabilities.scraper.rust import load_advisory
 
 RUSTSEC_DB_URL = 'https://github.com/RustSec/advisory-db/archive/master.zip'
 
 
+@pytest.mark.webtest
 def test_extract_data():
     for advisory in rust_crate_advisories(RUSTSEC_DB_URL):
         loaded_advisory = load_advisory(advisory)


### PR DESCRIPTION

This is done by adding pytest markers on the tests which require internet connections , thus they can be skipped if necessary easily.

Simply run `DJANGO_DEV=1 pytest  -m "not webtest"`

Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>