### PR TITLE
Fix Advisory.__hash__()

### DIFF
--- a/vulnerabilities/data_source.py
+++ b/vulnerabilities/data_source.py
@@ -61,9 +61,9 @@ class Advisory:
     def __hash__(self):
         s = '{}{}{}{}{}'.format(
             self.summary,
-            ''.join({str(p) for p in self.impacted_package_urls}),
-            ''.join({str(p) for p in self.resolved_package_urls}),
-            ''.join(self.reference_urls),
+            ''.join(sorted([str(p) for p in self.impacted_package_urls])),
+            ''.join(sorted([str(p) for p in self.resolved_package_urls])),
+            ''.join(sorted(self.reference_urls)),
             self.cve_id,
         )
         return hash(s)


### PR DESCRIPTION
The hash is computed from a string, which is built by iterating over attributes of type `Iterable`/`Sequence`, such as `impacted_package_urls`.

This change sorts those attributes before concatenating to the string, to avoid different hashes when the order of `impacted_package_urls`, etc differs.

NB A better solution would be to avoid implementing `__hash__()` and use immutable collections like tuple and frozenset for the above mentioned attributes instead.

See https://eng.lyft.com/hashing-and-equality-in-python-2ea8c738fb9d
