### PR TITLE
Add SUSE backport data source and it's tests

### DIFF
--- a/vulnerabilities/importers/suse_backports.py
+++ b/vulnerabilities/importers/suse_backports.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+import yaml
+import dataclasses
+
+import requests
+from packageurl import PackageURL
+from bs4 import BeautifulSoup
+
+from vulnerabilities.data_source import Advisory
+from vulnerabilities.data_source import DataSource
+from vulnerabilities.data_source import DataSourceConfiguration
+
+
+@dataclasses.dataclass
+class SUSEBackportsConfiguration(DataSourceConfiguration):
+    url: str
+    etags: dict
+
+
+class SUSEBackportsDataSource(DataSource):
+
+    CONFIG_CLASS = SUSEBackportsConfiguration
+
+    @staticmethod
+    def get_all_urls_of_backports(url):
+        r = requests.get(url)
+        soup = BeautifulSoup(r.content, 'lxml')
+        for a_tag in soup.find_all('a', href=True):
+            if a_tag['href'].endswith('.yaml') and a_tag['href'].startswith('backports'):
+                yield url + a_tag['href']
+
+    def updated_advisories(self):
+        advisories = []
+        all_urls = self.get_all_urls_of_backports(self.config.url)
+        for url in all_urls:
+            if not self.create_etag(url):
+                continue
+            advisories.extend(self.process_file(self._fetch_yaml(url)))
+        return self.batch_advisories(advisories)
+
+    def create_etag(self, url):
+        etag = requests.head(url).headers.get('ETag')
+        if not etag:
+            # Kind of inaccurate to return True since etag is
+            # not created
+            return True
+        elif url in self.config.etags:
+            if self.config.etags[url] == etag:
+                return False
+        self.config.etags[url] = etag
+        return True
+
+    def _fetch_yaml(self, url):
+
+        try:
+            resp = requests.get(url)
+            resp.raise_for_status()
+            return yaml.safe_load(resp.content)
+
+        except requests.HTTPError:
+            return {}
+
+    @staticmethod
+    def process_file(yaml_file):
+        advisories = []
+        try:
+            for pkg in yaml_file[0]['packages']:
+                for version in yaml_file[0]['packages'][pkg]['fixed']:
+                    for vuln in yaml_file[0]['packages'][pkg]['fixed'][version]:
+                        # yaml_file specific data can be added
+                        purl = [PackageURL(
+                            name=pkg, type="rpm", version=version)]
+                        advisories.append(
+                            Advisory(cve_id=vuln,
+                                     resolved_package_urls=purl,
+                                     summary='',
+                                     impacted_package_urls=[])
+                        )
+        except TypeError:
+            # could've used pass
+            return advisories
+
+        return advisories

--- a/vulnerabilities/importers/suse_backports.py
+++ b/vulnerabilities/importers/suse_backports.py
@@ -90,7 +90,7 @@ class SUSEBackportsDataSource(DataSource):
                     for vuln in yaml_file[0]['packages'][pkg]['fixed'][version]:
                         # yaml_file specific data can be added
                         purl = [PackageURL(
-                            name=pkg, type="rpm", version=version)]
+                            name=pkg, type="rpm", version=version, namespace='opensuse')]
                         advisories.append(
                             Advisory(cve_id=vuln,
                                      resolved_package_urls=purl,

--- a/vulnerabilities/migrations/0011_susebackports_importer.py
+++ b/vulnerabilities/migrations/0011_susebackports_importer.py
@@ -20,14 +20,37 @@
 #  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 
+from django.db import migrations
 
-from vulnerabilities.importers.alpine_linux import AlpineDataSource
-from vulnerabilities.importers.archlinux import ArchlinuxDataSource
-from vulnerabilities.importers.debian import DebianDataSource
-from vulnerabilities.importers.npm import NpmDataSource
-from vulnerabilities.importers.rust import RustDataSource
-from vulnerabilities.importers.safety_db import SafetyDbDataSource
-from vulnerabilities.importers.ruby import RubyDataSource
-from vulnerabilities.importers.ubuntu import UbuntuDataSource
-from vulnerabilities.importers.retiredotnet import RetireDotnetDataSource
-from vulnerabilities.importers.suse_backports import SUSEBackportsDataSource
+
+def add_suse_backports_importer(apps, _):
+    Importer = apps.get_model('vulnerabilities', 'Importer')
+
+    Importer.objects.create(
+        name='suse_backports',
+        license='',
+        last_run=None,
+        data_source='SUSEBackportsDataSource',
+        data_source_cfg={
+            'url':'http://ftp.suse.com/pub/projects/security/yaml/',
+            'etags':{},
+        },
+    )
+
+
+def remove_suse_backports_importer(apps, _):
+    Importer = apps.get_model('vulnerabilities', 'Importer')
+    qs = Importer.objects.filter(name='suse_backports')
+    if qs:
+        qs[0].delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('vulnerabilities', '0010_retiredotnet_importer'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_suse_backports_importer, remove_suse_backports_importer),
+    ]

--- a/vulnerabilities/tests/test_data/suse_backports/backports-sle11-sp0.yaml
+++ b/vulnerabilities/tests/test_data/suse_backports/backports-sle11-sp0.yaml
@@ -1,0 +1,21 @@
+---
+- name: SLES
+  version: 11
+  packages:
+    MozillaFirefox:
+      fixed:
+        3.0.10-1.1.1:
+          - CVE-2009-1313
+    MozillaFirefox-branding-SLED:
+      fixed:
+        3.5-1.1.5:
+          - CVE-2009-1313
+    MozillaFirefox-translations:
+      fixed:
+        3.0.10-1.1.1:
+          - CVE-2009-1313
+    NetworkManager:
+      fixed:
+        0.7.0.r4359-15.9.2:
+          - CVE-2009-0365
+          - CVE-2009-0578

--- a/vulnerabilities/tests/test_suse_backports.py
+++ b/vulnerabilities/tests/test_suse_backports.py
@@ -60,7 +60,7 @@ class TestSUSEBackportsDataSource(TestCase):
                 resolved_package_urls=[
                     PackageURL(
                         type='rpm',
-                        namespace=None,
+                        namespace='opensuse',
                         name='MozillaFirefox',
                         version='3.0.10-1.1.1',
                         qualifiers=OrderedDict(),
@@ -74,7 +74,7 @@ class TestSUSEBackportsDataSource(TestCase):
                 resolved_package_urls=[
                         PackageURL(
                             type='rpm',
-                            namespace=None,
+                            namespace='opensuse',
                             name='MozillaFirefox-branding-SLED',
                             version='3.5-1.1.5',
                             qualifiers=OrderedDict(),
@@ -88,7 +88,7 @@ class TestSUSEBackportsDataSource(TestCase):
                 resolved_package_urls=[
                     PackageURL(
                         type='rpm',
-                        namespace=None,
+                        namespace='opensuse',
                         name='MozillaFirefox-translations',
                         version='3.0.10-1.1.1',
                         qualifiers=OrderedDict(),
@@ -102,7 +102,7 @@ class TestSUSEBackportsDataSource(TestCase):
                 resolved_package_urls=[
                     PackageURL(
                         type='rpm',
-                        namespace=None,
+                        namespace='opensuse',
                         name='NetworkManager',
                         version='0.7.0.r4359-15.9.2',
                         qualifiers=OrderedDict(),
@@ -116,7 +116,7 @@ class TestSUSEBackportsDataSource(TestCase):
                 resolved_package_urls=[
                     PackageURL(
                         type='rpm',
-                        namespace=None,
+                        namespace='opensuse',
                         name='NetworkManager',
                         version='0.7.0.r4359-15.9.2',
                         qualifiers=OrderedDict(),

--- a/vulnerabilities/tests/test_suse_backports.py
+++ b/vulnerabilities/tests/test_suse_backports.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+from collections import OrderedDict
+import os
+from unittest import TestCase
+import yaml
+
+from packageurl import PackageURL
+
+from vulnerabilities.importers.suse_backports import SUSEBackportsDataSource
+from vulnerabilities.data_source import Advisory
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def yaml_loader():
+    path = os.path.join(BASE_DIR, "test_data/suse_backports/")
+    yaml_files = {}
+    for file in os.listdir(path):
+        with open(os.path.join(path, file)) as f:
+            yaml_files[file] = yaml.safe_load(f)
+    return yaml_files
+
+
+class TestSUSEBackportsDataSource(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        data_source_cfg = {
+            'url': 'https://endpoint.com',
+            'etags': {}}
+        cls.data_src = SUSEBackportsDataSource(1, config=data_source_cfg)
+
+    def test_process_file(self):
+        parsed_yamls = yaml_loader()
+        expected_data = [
+            Advisory(
+                summary='',
+                impacted_package_urls=[],
+                resolved_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace=None,
+                        name='MozillaFirefox',
+                        version='3.0.10-1.1.1',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                reference_urls=[],
+                reference_ids=[],
+                cve_id='CVE-2009-1313'),
+            Advisory(
+                summary='',
+                impacted_package_urls=[],
+                resolved_package_urls=[
+                        PackageURL(
+                            type='rpm',
+                            namespace=None,
+                            name='MozillaFirefox-branding-SLED',
+                            version='3.5-1.1.5',
+                            qualifiers=OrderedDict(),
+                            subpath=None)],
+                reference_urls=[],
+                reference_ids=[],
+                cve_id='CVE-2009-1313'),
+            Advisory(
+                summary='',
+                impacted_package_urls=[],
+                resolved_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace=None,
+                        name='MozillaFirefox-translations',
+                        version='3.0.10-1.1.1',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                reference_urls=[],
+                reference_ids=[],
+                cve_id='CVE-2009-1313'),
+            Advisory(
+                summary='',
+                impacted_package_urls=[],
+                resolved_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace=None,
+                        name='NetworkManager',
+                        version='0.7.0.r4359-15.9.2',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                reference_urls=[],
+                reference_ids=[],
+                cve_id='CVE-2009-0365'),
+            Advisory(
+                summary='',
+                impacted_package_urls=[],
+                resolved_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace=None,
+                        name='NetworkManager',
+                        version='0.7.0.r4359-15.9.2',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                reference_urls=[],
+                reference_ids=[],
+                cve_id='CVE-2009-0578'),
+        ]
+
+        found_data = self.data_src.process_file(
+            parsed_yamls['backports-sle11-sp0.yaml'])
+        assert expected_data == found_data


### PR DESCRIPTION
This data is imported from http://ftp.suse.com/pub/projects/security/yaml/ , these are backports of previously vulnerable versions of packages, hence don't result into creation of `ImpactedPackages`. 

**Note**  : This data is different from SUSE OVAL files.

Gets close to  fix : https://github.com/nexB/vulnerablecode/issues/62  https://github.com/nexB/vulnerablecode/issues/84

Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>