### PR TITLE
Use JSONField instead of CharField to store a Package's qualifers

### DIFF
--- a/vulnerabilities/import_runner.py
+++ b/vulnerabilities/import_runner.py
@@ -172,7 +172,7 @@ def _get_or_create_package(p: PackageURL) -> Tuple[models.Package, bool]:
         query_kwargs['namespace'] = packageurl.normalize_namespace(p.namespace, p.type, encode=True)
 
     if p.qualifiers:
-        query_kwargs['qualifiers'] = packageurl.normalize_qualifiers(p.qualifiers, encode=True)
+        query_kwargs['qualifiers'] = packageurl.normalize_qualifiers(p.qualifiers, encode=False)
 
     if p.subpath:
         query_kwargs['subpath'] = packageurl.normalize_subpath(p.subpath, encode=True)

--- a/vulnerabilities/migrations/0001_initial.py
+++ b/vulnerabilities/migrations/0001_initial.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 ('namespace', models.CharField(blank=True, help_text='Package name prefix, such as Maven groupid, Docker image owner, GitHub user or organization, etc.', max_length=255, null=True)),
                 ('name', models.CharField(blank=True, help_text='Name of the package.', max_length=100, null=True)),
                 ('version', models.CharField(blank=True, help_text='Version of the package.', max_length=100, null=True)),
-                ('qualifiers', models.CharField(blank=True, help_text='Extra qualifying data for a package such as the name of an OS, architecture, distro, etc.', max_length=1024, null=True)),
+                ('qualifiers', django.contrib.postgres.fields.jsonb.JSONField(default=dict, null=True, help_text='Extra qualifying data for a package such as the name of an OS, architecture, distro, etc.')),
                 ('subpath', models.CharField(blank=True, help_text='Extra subpath within a package, relative to the package root.', max_length=200, null=True)),
             ],
             options={

--- a/vulnerabilities/tests/test_alpine.py
+++ b/vulnerabilities/tests/test_alpine.py
@@ -98,7 +98,7 @@ class AlpineImportTest(TestCase):
         assert qs
 
         if arch:
-            pkg = qs.get(qualifiers__contains=arch)
+            pkg = qs.get(qualifiers__arch=arch)
         else:
             pkg = qs[0]
 

--- a/vulnerabilities/tests/test_debian.py
+++ b/vulnerabilities/tests/test_debian.py
@@ -84,7 +84,7 @@ class DebianImportTest(TestCase):
             type='deb',
             namespace='debian',
         )
-        qs = qs.filter(qualifiers__contains=release)
+        qs = qs.filter(qualifiers__distro=release)
         assert qs
 
         if cve_ids:


### PR DESCRIPTION
This how it looks in the DB now, after completing the debian importer.

Fixes https://github.com/nexB/vulnerablecode/issues/149, now our models are capable of capturing qualifiers properly. 

![qualifiers](https://user-images.githubusercontent.com/28975399/84269622-144f7200-ab47-11ea-87ee-1f7c5e3cd336.png)

Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>