### PR TITLE
Add red hat importer and it's tests

### DIFF
--- a/vulnerabilities/importers/redhat.py
+++ b/vulnerabilities/importers/redhat.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+import requests
+
+from packageurl import PackageURL
+
+from vulnerabilities.data_source import Advisory
+from vulnerabilities.data_source import DataSource
+from vulnerabilities.data_source import DataSourceConfiguration
+
+
+class RedhatDataSource(DataSource):
+    CONFIG_CLASS = DataSourceConfiguration
+
+    def __enter__(self):
+
+        self.redhat_response = fetch()
+
+    def updated_advisories(self):
+        processed_advisories = []
+        for advisory_data in self.redhat_response:
+            processed_advisories.append(to_advisory(advisory_data))
+
+        return self.batch_advisories(processed_advisories)
+
+
+def fetch():
+
+    response = []
+    page_no = 1
+    url = "https://access.redhat.com/hydra/rest/securitydata/cve.json?page={}"
+
+    while True:
+
+        resp_json = requests.get(url.format(page_no)).json()
+        page_no += 1
+        if not resp_json:
+            break
+
+        for advisory in resp_json:
+            response.append(advisory)
+
+    return response
+
+
+def to_advisory(advisory_data):
+
+    affected_purls = []
+    if advisory_data.get('affected_packages'):
+        for rpm in advisory_data['affected_packages']:
+            if rpm_to_purl(rpm):
+                affected_purls.append(rpm_to_purl(rpm))
+
+    return Advisory(
+        summary=advisory_data['bugzilla_description'],
+        cve_id=advisory_data['CVE'],
+        reference_ids=advisory_data['advisories'],
+        impacted_package_urls=affected_purls,
+        reference_urls=[advisory_data['resource_url']],
+    )
+
+
+def rpm_to_purl(rpm_string):
+
+    # Red Hat uses `-:0` instead of just `-` to separate
+    # package name and version
+    components = rpm_string.split('-0:')
+    if len(components) != 2:
+        return
+
+    name, version = components
+
+    if version[0].isdigit():
+        return PackageURL(name=name, type='rpm', version=version, namespace="redhat")

--- a/vulnerabilities/migrations/0013_redhat_importer.py
+++ b/vulnerabilities/migrations/0013_redhat_importer.py
@@ -20,16 +20,33 @@
 #  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 
+from django.db import migrations
 
-from vulnerabilities.importers.alpine_linux import AlpineDataSource
-from vulnerabilities.importers.archlinux import ArchlinuxDataSource
-from vulnerabilities.importers.debian import DebianDataSource
-from vulnerabilities.importers.npm import NpmDataSource
-from vulnerabilities.importers.rust import RustDataSource
-from vulnerabilities.importers.safety_db import SafetyDbDataSource
-from vulnerabilities.importers.ruby import RubyDataSource
-from vulnerabilities.importers.ubuntu import UbuntuDataSource
-from vulnerabilities.importers.retiredotnet import RetireDotnetDataSource
-from vulnerabilities.importers.suse_backports import SUSEBackportsDataSource
-from vulnerabilities.importers.debian_oval import DebianOvalDataSource
-from vulnerabilities.importers.redhat import RedhatDataSource
+
+def add_redhat_importer(apps, _):
+    Importer = apps.get_model('vulnerabilities', 'Importer')
+
+    Importer.objects.create(
+        name='redhat',
+        license='',
+        last_run=None,
+        data_source='RedhatDataSource',
+    )
+
+
+def remove_redhat_importer(apps, _):
+    Importer = apps.get_model('vulnerabilities', 'Importer')
+    qs = Importer.objects.filter(name='redhat')
+    if qs:
+        qs[0].delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('vulnerabilities', '0012_debian_oval_importer'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_redhat_importer, remove_redhat_importer),
+    ]

--- a/vulnerabilities/tests/test_data/redhat.json
+++ b/vulnerabilities/tests/test_data/redhat.json
@@ -1,0 +1,72 @@
+    [   {      "CVE":"CVE-2016-10200",
+        "severity":"important",
+        "public_date":"2016-11-18T00:00:00Z",
+        "advisories":[
+        "RHSA-2017:1842",
+        "RHSA-2017:2437",
+        "RHSA-2017:2077",
+        "RHSA-2017:2444"
+        
+    ],
+        "bugzilla":"1430347",
+        "bugzilla_description":"CVE-2016-10200 kernel: l2tp: Race condition in the L2TPv3 IP encapsulation feature",
+        "cvss_score":null,
+        "cvss_scoring_vector":null,
+        "CWE":"CWE-362",
+        "affected_packages":[
+        "kernel-rt-0:3.10.0-693.rt56.617.el7",
+        "kernel-0:3.10.0-693.el7",
+        "kernel-0:3.10.0-514.28.1.el7",
+        "kernel-rt-1:3.10.0-514.rt56.231.el6rt"
+        
+    ],
+        "resource_url":"https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2016-10200.json",
+        "cvss3_scoring_vector":"CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "cvss3_score":"7.0"
+    
+    },
+    {      "CVE":"CVE-2017-12168",
+        "severity":"moderate",
+        "public_date":"2016-11-18T00:00:00Z",
+        "advisories":[
+
+        
+    ],
+        "bugzilla":"1492984",
+        "bugzilla_description":"CVE-2017-12168 Kernel: kvm: ARM64: assert failure when accessing PMCCNTR register",
+        "cvss_score":5.2,
+        "cvss_scoring_vector":"AV:A/AC:M/Au:S/C:N/I:N/A:C",
+        "CWE":"CWE-617",
+        "affected_packages":[
+
+        
+    ],
+        "resource_url":"https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2017-12168.json",
+        "cvss3_scoring_vector":"CVSS:3.0/AV:A/AC:L/PR:H/UI:N/S:C/C:N/I:N/A:H",
+        "cvss3_score":"6.2"
+    
+    },
+    {      "CVE":"CVE-2016-9401",
+        "severity":"low",
+        "public_date":"2016-11-17T00:00:00Z",
+        "advisories":[
+        "RHSA-2017:1931",
+        "RHSA-2017:0725"
+        
+    ],
+        "bugzilla":"1396383",
+        "bugzilla_description":"CVE-2016-9401 bash: popd controlled free",
+        "cvss_score":1.9,
+        "cvss_scoring_vector":"AV:L/AC:M/Au:N/C:N/I:N/A:P",
+        "CWE":"CWE-416",
+        "affected_packages":[
+        "bash-0:4.2.46-28.el7",
+        "bash-0:4.1.2-48.el6"
+        
+    ],
+        "resource_url":"https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2016-9401.json",
+        "cvss3_scoring_vector":"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+        "cvss3_score":"3.3"
+    
+    }
+]

--- a/vulnerabilities/tests/test_redhat_importer.py
+++ b/vulnerabilities/tests/test_redhat_importer.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+import json
+import os
+import unittest
+from collections import OrderedDict
+
+from packageurl import PackageURL
+
+import vulnerabilities.importers.redhat as redhat
+from vulnerabilities.data_source import Advisory
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_DATA = os.path.join(BASE_DIR, 'test_data/', 'redhat.json')
+
+
+def load_test_data():
+    with open(TEST_DATA) as f:
+        return json.load(f)
+
+
+class TestRedhat(unittest.TestCase):
+
+    def test_rpm_to_purl(self):
+
+        assert redhat.rpm_to_purl("foobar") is None
+        assert redhat.rpm_to_purl("foo-bar-devel-0:sys76") is None
+        assert redhat.rpm_to_purl("kernel-0:2.6.32-754.el6") == PackageURL(
+            type='rpm',
+            namespace='redhat',
+            name='kernel',
+            version='2.6.32-754.el6',
+            qualifiers=OrderedDict(),
+            subpath=None)
+
+    def test_to_advisory(self):
+        data = load_test_data()
+        expected_data = {
+            Advisory(
+                summary='CVE-2016-9401 bash: popd controlled free',
+                impacted_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace='redhat',
+                        name='bash',
+                        version='4.2.46-28.el7',
+                        qualifiers=OrderedDict(),
+                        subpath=None),
+                    PackageURL(
+                        type='rpm',
+                        namespace='redhat',
+                        name='bash',
+                        version='4.1.2-48.el6',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                resolved_package_urls=[],
+                reference_urls=[
+                    'https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2016-9401.json'],
+                reference_ids=[
+                    'RHSA-2017:1931',
+                    'RHSA-2017:0725'],
+                cve_id='CVE-2016-9401'),
+            Advisory(
+                summary=('CVE-2016-10200 kernel: l2tp: Race condition '
+                         'in the L2TPv3 IP encapsulation feature'),
+                impacted_package_urls=[
+                    PackageURL(
+                        type='rpm',
+                        namespace='redhat',
+                        name='kernel-rt',
+                        version='3.10.0-693.rt56.617.el7',
+                        qualifiers=OrderedDict(),
+                        subpath=None),
+                    PackageURL(
+                        type='rpm',
+                        namespace='redhat',
+                        name='kernel',
+                        version='3.10.0-693.el7',
+                        qualifiers=OrderedDict(),
+                        subpath=None),
+                    PackageURL(
+                        type='rpm',
+                        namespace='redhat',
+                        name='kernel',
+                        version='3.10.0-514.28.1.el7',
+                        qualifiers=OrderedDict(),
+                        subpath=None)],
+                resolved_package_urls=[],
+                reference_urls=[
+                    'https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2016-10200.json'],
+                reference_ids=[
+                    'RHSA-2017:1842',
+                    'RHSA-2017:2437',
+                    'RHSA-2017:2077',
+                    'RHSA-2017:2444'],
+                cve_id='CVE-2016-10200'),
+            Advisory(
+                summary=('CVE-2017-12168 Kernel: kvm: ARM64: '
+                         'assert failure when accessing PMCCNTR register'),
+                impacted_package_urls=[],
+                resolved_package_urls=[],
+                reference_urls=[
+                    'https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2017-12168.json'],
+                reference_ids=[],
+                cve_id='CVE-2017-12168'),
+        }
+
+        found_data = set()
+        for adv in data:
+            found_data.add(redhat.to_advisory(adv))
+        assert expected_data == found_data


### PR DESCRIPTION
Data is imported from  https://access.redhat.com/hydra/rest/securitydata/cve.json 

Fixes https://github.com/nexB/vulnerablecode/issues/44

Here is a glimpse of the data provided by this importer 
![Screenshot_20200611_182105](https://user-images.githubusercontent.com/28975399/84388394-234f2680-ac12-11ea-9b64-b96ca021be94.png)


Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>