### PR TITLE
[EXPERIMENT] New models

### DIFF
--- a/vulnerabilities/admin.py
+++ b/vulnerabilities/admin.py
@@ -24,10 +24,9 @@
 from django.contrib import admin
 
 from vulnerabilities.models import (
-    ImpactedPackage,
+    Vulnerability_Package_Relation,
     Importer,
     Package,
-    ResolvedPackage,
     Vulnerability,
     VulnerabilityReference,
 )
@@ -48,13 +47,8 @@ class PackageAdmin(admin.ModelAdmin):
     pass
 
 
-@admin.register(ImpactedPackage)
+@admin.register(Vulnerability_Package_Relation)
 class ImpactedPackageAdmin(admin.ModelAdmin):
-    pass
-
-
-@admin.register(ResolvedPackage)
-class ResolvedPackageAdmin(admin.ModelAdmin):
     pass
 
 

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -33,6 +33,53 @@ from packageurl import PackageURL
 
 from vulnerabilities.data_source import DataSource
 
+class Importer(models.Model):
+    """
+    Metadata and pointer to the implementation for a source of vulnerability data (aka security
+    advisories)
+    """
+    name = models.CharField(max_length=100, unique=True, help_text='Name of the importer')
+
+    license = models.CharField(
+        max_length=100,
+        blank=True,
+        help_text='License of the vulnerability data',
+    )
+
+    last_run = models.DateTimeField(null=True, help_text='UTC Timestamp of the last run')
+
+    data_source = models.CharField(
+        max_length=100,
+        help_text='Name of the data source implementation importable from vulnerabilities.importers'
+    )
+    data_source_cfg = pgfields.JSONField(
+        null=False,
+        default=dict,
+        help_text='Implementation-specific configuration for the data source',
+    )
+
+    def make_data_source(self, batch_size: int, cutoff_date: datetime = None) -> DataSource:
+        """
+        Return a configured and ready to use instance of this importers data source implementation.
+
+        batch_size - max. number of records to return on each iteration
+        cutoff_date - optional timestamp of the oldest data to include in the import
+        """
+        importers_module = importlib.import_module('vulnerabilities.importers')
+        klass = getattr(importers_module, self.data_source)
+
+        ds = klass(
+            batch_size,
+            last_run_date=self.last_run,
+            cutoff_date=cutoff_date,
+            config=self.data_source_cfg,
+        )
+
+        return ds
+
+    def __str__(self):
+        return self.name
+
 
 class Vulnerability(models.Model):
     """
@@ -63,9 +110,9 @@ class VulnerabilityReference(models.Model):
     package manager.
     """
     vulnerability = models.ForeignKey(
-        Vulnerability, on_delete=models.CASCADE, required=True)    
+        Vulnerability, on_delete=models.CASCADE)    
     source = models.ForeignKey(
-        Importer, on_delete=models.CASCADE, required=True)
+        Importer, on_delete=models.CASCADE)
     urls = pgfields.JSONField()
     summary = models.TextField()
 
@@ -73,9 +120,9 @@ class VulnerabilityReference(models.Model):
         unique_together = ('vulnerability', 'source')
 
 class VulnerabilityScore(models.Model):
-  vulnerability_reference = models.ForeignKey(VulnerabilityReference, on_delete=models.CASCADE, required=True)
+  vulnerability_reference = models.ForeignKey(VulnerabilityReference, on_delete=models.CASCADE)
   type = models.CharField(max_length=50, help_text='Vulnerability score type', blank=True)
-  score = models.CharField()
+  score = models.CharField(max_length=50)
 
 class Package(PackageURLMixin):
     """
@@ -127,54 +174,7 @@ class Vulnerability_Package_Relation(models.Model):
     is_vulnerable = models.BooleanField()
 # } till this point we have a consensus in this model
 
-    version_range = models.CharField()
+    version_range = models.CharField(max_length=50)
 
     class Meta:
         unique_together = ('vulnerability', 'package')
-
-class Importer(models.Model):
-    """
-    Metadata and pointer to the implementation for a source of vulnerability data (aka security
-    advisories)
-    """
-    name = models.CharField(max_length=100, unique=True, help_text='Name of the importer')
-
-    license = models.CharField(
-        max_length=100,
-        blank=True,
-        help_text='License of the vulnerability data',
-    )
-
-    last_run = models.DateTimeField(null=True, help_text='UTC Timestamp of the last run')
-
-    data_source = models.CharField(
-        max_length=100,
-        help_text='Name of the data source implementation importable from vulnerabilities.importers'
-    )
-    data_source_cfg = pgfields.JSONField(
-        null=False,
-        default=dict,
-        help_text='Implementation-specific configuration for the data source',
-    )
-
-    def make_data_source(self, batch_size: int, cutoff_date: datetime = None) -> DataSource:
-        """
-        Return a configured and ready to use instance of this importers data source implementation.
-
-        batch_size - max. number of records to return on each iteration
-        cutoff_date - optional timestamp of the oldest data to include in the import
-        """
-        importers_module = importlib.import_module('vulnerabilities.importers')
-        klass = getattr(importers_module, self.data_source)
-
-        ds = klass(
-            batch_size,
-            last_run_date=self.last_run,
-            cutoff_date=cutoff_date,
-            config=self.data_source_cfg,
-        )
-
-        return ds
-
-    def __str__(self):
-        return self.name

--- a/vulnerablecode/settings.py
+++ b/vulnerablecode/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'vulnerabilities',
     'rest_framework',
     'django_filters',
+    'django_extensions'
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>

![vuln](https://user-images.githubusercontent.com/28975399/85740050-eeb59180-b71e-11ea-90b6-c69761918054.png)

The problems and how the new models solve them:

Problem 1 : A row in VulnerabilityReference does not properly encapsulate the reference ids and urls. Consider an importer encounters 2 distinct reference ids for a vulnerability, say USN-A and DSA-B and 2 corresponding urls 'www.USN-A.org' and 'www.DSA-B.org'. With the current implementation, A VulnerabilityReference can contain only single url and a single reference_id. What ends up happening is we either end up making 4 VulnerabilityReference row, like 

|....|USN A          | NULL             |
|....|DSA B          | NULL             |
|....|NULL            | 'www.USN-A.org' |
|....|NULL            | 'www.DSA-B.org'|

 or  have rows of combinations of reference_id and url , which might be unrelated. 

Problem 2: The `summary` of a vulnerability does not really belong in the Vulnerability table. Remember that vendors publish advisories in context of vulnerable packages, so the summary is usually related to the affected package + the vulnerability's nature. What happens in current implementation is, that the `summary` is overwritted  and replaced by the `summary` found by  last importer. 

Problem 3: Vulnerability scores, check https://github.com/nexB/vulnerablecode/issues/157

What this model lacks : 

1. Can't store version intervals. Suppose a vulnerability affects versions of a package lying in the interval [1.0, 3.0], there is no way to store that . On the other hand storing data which says all versions of package foo < 3.0 are vulnerable is possible. Ranges must  have only one bound, for this model to work.

