### PR TITLE
Use yield to save memory in OvalDataSource's updated_advisories

### DIFF
--- a/vulnerabilities/data_source.py
+++ b/vulnerabilities/data_source.py
@@ -435,10 +435,8 @@ class OvalDataSource(DataSource):
         """
         Note: metadata MUST INCLUDE "type" key, implement _fetch accordingly.
         """
-        advisories = []
         for metadata, oval_file in self._fetch():
-            advisories.extend(self.get_data_from_xml_doc(oval_file, metadata))
-        return self.batch_advisories(advisories)
+            yield self.get_data_from_xml_doc(oval_file, metadata)
 
     def set_api(self, all_pkgs: Iterable[str]):
         """


### PR DESCRIPTION
Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>

This small change enables huge imports to run without consuming all the RAM