### PR TITLE
Always store summary of vulnerability

### DIFF
--- a/vulnerabilities/import_runner.py
+++ b/vulnerabilities/import_runner.py
@@ -152,7 +152,7 @@ def _get_or_create_vulnerability(advisory: Advisory) -> Tuple[models.Vulnerabili
 
     vuln, created = models.Vulnerability.objects.get_or_create(**query_kwargs)
 
-    if not created and vuln.summary != advisory.summary:
+    if advisory.summary and vuln.summary != advisory.summary:
         vuln.summary = advisory.summary
         vuln.save()
 


### PR DESCRIPTION
Before this change, when a new vulnerability was stored for an advisory that has both a CVE ID and a summary, the summary was not included.