### PR TITLE
Use ayncio for making  API  calls to obtain package versions

### DIFF
--- a/vulnerabilities/importers/github.py
+++ b/vulnerabilities/importers/github.py
@@ -29,7 +29,6 @@ from typing import Tuple
 from typing import List
 from typing import Mapping
 from typing import Optional
-import xml.etree.ElementTree as ET
 
 import requests
 from dephell_specifier import RangeSpecifier
@@ -40,6 +39,9 @@ from vulnerabilities.data_source import DataSource
 from vulnerabilities.data_source import DataSourceConfiguration
 from vulnerabilities.data_source import Reference
 
+from vulnerabilities.package_managers import MavenVersionAPI
+from vulnerabilities.package_managers import NugetVersionAPI
+from vulnerabilities.package_managers import ComposerVersionAPI
 
 # set of all possible values of first '%s' = {'MAVEN','COMPOSER', 'NUGET'}
 # second '%s' is interesting, it will have the value '' for the first request,
@@ -213,116 +215,3 @@ class GitHubAPIDataSource(DataSource):
         affected_versions = {
             version for version in all_versions if version in version_range}
         return (affected_versions, all_versions - affected_versions)
-
-
-class MavenVersionAPI:
-    def __init__(self):
-        self.cache = {}
-
-    def get(self, pkg_name: str) -> Set[str]:
-        return self.cache.get(pkg_name, set())
-
-    def load_to_api(self, pkg_name: str) -> None:
-        if pkg_name in self.cache:
-            return
-
-        artifact_comps = pkg_name.split(":")
-        endpoint = self.artifact_url(artifact_comps)
-        resp = requests.get(endpoint).content
-
-        try:
-            xml_resp = ET.ElementTree(ET.fromstring(resp.decode("utf-8")))
-            self.cache[pkg_name] = self.extract_versions(xml_resp)
-        except ET.ParseError:
-            self.cache[pkg_name] = set()
-
-    @staticmethod
-    def artifact_url(artifact_comps: List[str]) -> str:
-        base_url = "https://repo.maven.apache.org/maven2/{}"
-        group_id, artifact_id = artifact_comps
-        group_url = group_id.replace(".", "/")
-        suffix = group_url + "/" + artifact_id + "/" + "maven-metadata.xml"
-        endpoint = base_url.format(suffix)
-
-        return endpoint
-
-    @staticmethod
-    def extract_versions(xml_response: ET.ElementTree) -> Set[str]:
-        all_versions = set()
-        for child in xml_response.getroot().iter():
-            if child.tag == "version":
-                all_versions.add(child.text)
-
-        return all_versions
-
-
-class NugetVersionAPI:
-    def __init__(self):
-        self.cache = {}
-
-    def get(self, pkg_name: str) -> Set[str]:
-        return self.cache.get(pkg_name.lower(), set())
-
-    def load_to_api(self, pkg_name: str) -> None:
-        if pkg_name in self.cache:
-            return
-        endpoint = self.nuget_url(pkg_name)
-        try:
-            resp = requests.get(endpoint).json()
-        # pkg_name=Microsoft.NETCore.UniversalWindowsPlatform triggers
-        # JSONDecodeError.
-        except json.decoder.JSONDecodeError:
-            self.cache[pkg_name.lower()] = set()
-            return
-
-        self.cache[pkg_name.lower()] = self.extract_versions(resp)
-
-    @staticmethod
-    def nuget_url(pkg_name: str) -> str:
-        base_url = "https://api.nuget.org/v3/registration5-semver1/{}/index.json"
-        return base_url.format(pkg_name.lower())
-
-    @staticmethod
-    def extract_versions(resp: dict) -> Set[str]:
-        all_versions = set()
-
-        try:
-            for entry in resp["items"][0]["items"]:
-                all_versions.add(entry["catalogEntry"]["version"])
-        # json response for YamlDotNet.Signed triggers this exception
-        except KeyError:
-            pass
-
-        return all_versions
-
-
-class ComposerVersionAPI:
-    def __init__(self):
-        self.cache = {}
-
-    def get(self, pkg_name: str) -> Set[str]:
-        return self.cache.get(pkg_name.lower(), set())
-
-    def load_to_api(self, pkg_name: str) -> None:
-        if pkg_name in self.cache:
-            return
-
-        endpoint = self.composer_url(pkg_name)
-        json_resp = requests.get(endpoint).json()
-        self.cache[pkg_name] = self.extract_versions(json_resp, pkg_name)
-
-    @staticmethod
-    def composer_url(pkg_name: str) -> str:
-        vendor, name = pkg_name.split("/")
-        return f"https://repo.packagist.org/p/{vendor}/{name}.json"
-
-    @staticmethod
-    def extract_versions(resp: dict, pkg_name: str) -> Set[str]:
-        all_versions = resp["packages"][pkg_name].keys()
-        # This filter ensures, that all_versions contains only released versions
-        all_versions = set(filter(lambda x: "dev" not in x, all_versions))
-        # See https://github.com/composer/composer/blob/44a4429978d1b3c6223277b875762b2930e83e8c/doc/articles/versions.md#tags  # nopep8
-        # for explanation of removing 'v'
-        all_versions = set(map(lambda x: x.replace("v", ""), all_versions))
-
-        return all_versions

--- a/vulnerabilities/importers/npm.py
+++ b/vulnerabilities/importers/npm.py
@@ -38,6 +38,7 @@ from packageurl import PackageURL
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import GitDataSource
 from vulnerabilities.data_source import Reference
+from vulnerabilities.package_managers import NpmVersionAPI
 
 NPM_URL = 'https://registry.npmjs.org{}'
 
@@ -130,31 +131,3 @@ def categorize_versions(
             aff_ver.add(ver)
 
     return aff_ver, fix_ver
-
-
-class VersionAPI:
-    def __init__(self, cache: Mapping[str, Set[str]] = None):
-        self.cache = cache or {}
-
-    def get(self, package_name: str) -> Set[str]:
-        """
-        Returns all versions available for a module
-        """
-        package_name = package_name.strip()
-
-        if package_name not in self.cache:
-            releases = set()
-            try:
-                with urlopen(f"https://registry.npmjs.org/{package_name}") as response:
-                    data = json.load(response)
-                    releases = {v for v in data.get("versions", {})}
-            except HTTPError as e:
-                if e.code == 404:
-                    # NPM registry has no data regarding this package, we skip these
-                    pass
-                else:
-                    raise
-
-            self.cache[package_name] = releases
-
-        return self.cache[package_name]

--- a/vulnerabilities/importers/npm.py
+++ b/vulnerabilities/importers/npm.py
@@ -47,7 +47,7 @@ class NpmDataSource(GitDataSource):
 
     def __enter__(self):
         super(NpmDataSource, self).__enter__()
-        self._versions = VersionAPI()
+        self._versions = NpmVersionAPI()
         if not getattr(self, '_added_files', None):
             self._added_files, self._updated_files = self.file_changes(
                 recursive=True, file_ext='json', subdir='./vuln/npm')

--- a/vulnerabilities/importers/npm.py
+++ b/vulnerabilities/importers/npm.py
@@ -21,6 +21,7 @@
 #  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 
+import asyncio
 import json
 from typing import Any
 from typing import List
@@ -40,17 +41,19 @@ from vulnerabilities.data_source import GitDataSource
 from vulnerabilities.data_source import Reference
 from vulnerabilities.package_managers import NpmVersionAPI
 
-NPM_URL = 'https://registry.npmjs.org{}'
+NPM_URL = "https://registry.npmjs.org{}"
 
 
 class NpmDataSource(GitDataSource):
-
     def __enter__(self):
         super(NpmDataSource, self).__enter__()
-        self._versions = NpmVersionAPI()
-        if not getattr(self, '_added_files', None):
+        if not getattr(self, "_added_files", None):
             self._added_files, self._updated_files = self.file_changes(
-                recursive=True, file_ext='json', subdir='./vuln/npm')
+                recursive=True, file_ext="json", subdir="./vuln/npm"
+            )
+
+        self._versions = NpmVersionAPI()
+        self.set_api(self.collect_packages())
 
     def updated_advisories(self) -> Set[Advisory]:
         files = self._updated_files.union(self._added_files)
@@ -61,15 +64,27 @@ class NpmDataSource(GitDataSource):
                 advisories.extend(processed_data)
         return self.batch_advisories(advisories)
 
+    def set_api(self, packages):
+        asyncio.run(self._versions.load_api(packages))
+
+    def collect_packages(self):
+        packages = set()
+        files = self._updated_files.union(self._added_files)
+        for f in files:
+            data = load_json(f)
+            packages.add(data["module_name"].strip())
+
+        return packages
+
     @property
     def versions(self):  # quick hack to make it patchable
         return self._versions
 
     def process_file(self, file) -> List[Advisory]:
-        with open(file) as f:
-            record = json.load(f)
+
+        record = load_json(file)
         advisories = []
-        package_name = record["module_name"]
+        package_name = record["module_name"].strip()
         all_versions = self.versions.get(package_name)
         aff_range = record.get("vulnerable_versions", "")
         fixed_range = record.get("patched_versions", "")
@@ -131,3 +146,8 @@ def categorize_versions(
             aff_ver.add(ver)
 
     return aff_ver, fix_ver
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)

--- a/vulnerabilities/importers/ruby.py
+++ b/vulnerabilities/importers/ruby.py
@@ -33,6 +33,7 @@ import yaml
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import GitDataSource
 from vulnerabilities.data_source import Reference
+from vulnerabilities.package_managers import RubyVersionAPI
 
 
 class RubyDataSource(GitDataSource):
@@ -85,7 +86,7 @@ class RubyDataSource(GitDataSource):
             safe_version_ranges = [i for i in safe_version_ranges if i]
 
             if not getattr(self, 'pkg_manager_api', None):
-                self.pkg_manager_api = rubyAPI()
+                self.pkg_manager_api = RubyVersionAPI()
             all_vers = self.pkg_manager_api.get_all_version_of_package(
                 package_name)
             safe_versions, affected_versions = self.categorize_versions(
@@ -138,32 +139,3 @@ class RubyDataSource(GitDataSource):
                     safe_versions.add(i)
 
         return (safe_versions, all_versions-safe_versions)
-
-
-class rubyAPI:
-
-    base_endpt = 'https://rubygems.org/api/v1/versions/{}.json'
-
-    def __init__(self):
-        self.client = requests.Session()
-        self.cache = {}
-
-    def call_api(self, pkg_name) -> List:
-        end_pt = self.base_endpt.format(pkg_name)
-        try:
-            resp = self.client.get(end_pt)
-            return resp.json()
-        # this covers 404 alright
-        except JSONDecodeError:
-            return []
-
-    def get_all_version_of_package(self, pkg_name) -> Set[str]:
-        all_versions = set()
-        if self.cache.get(pkg_name):
-            return self.cache.get(pkg_name)
-
-        json_resp = self.call_api(pkg_name)
-        for release in json_resp:
-            all_versions.add(release['number'])
-        self.cache[pkg_name] = all_versions
-        return all_versions

--- a/vulnerabilities/importers/rust.py
+++ b/vulnerabilities/importers/rust.py
@@ -35,6 +35,7 @@ from packageurl import PackageURL
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import GitDataSource
 from vulnerabilities.data_source import Reference
+from vulnerabilities.package_managers import CratesVersionAPI
 
 
 class RustDataSource(GitDataSource):
@@ -50,8 +51,8 @@ class RustDataSource(GitDataSource):
 
     @property
     def crates_api(self):
-        if not hasattr(self, "_crates_api"):
-            setattr(self, "_crates_api", VersionAPI())
+        if not hasattr(self, '_crates_api'):
+            setattr(self, '_crates_api', CratesVersionAPI())
         return self._crates_api
 
     def added_advisories(self) -> Set[Advisory]:
@@ -160,29 +161,3 @@ def categorize_versions(
             unaffected.update(uncategorized_versions)
 
     return unaffected, affected
-
-
-class VersionAPI:
-    def __init__(self, cache: Mapping[str, Set[str]] = None):
-        self.cache = cache or {}
-
-    def get(self, package_name: str) -> Set[str]:
-        package_name = package_name.strip()
-
-        if package_name not in self.cache:
-            releases = set()
-
-            try:
-                with urlopen(f"https://crates.io/api/v1/crates/{package_name}") as response:
-                    response = json.load(response)
-                    for version_info in response["versions"]:
-                        releases.add(version_info["num"])
-            except HTTPError as e:
-                if e.code == 404:
-                    pass
-                else:
-                    raise
-
-            self.cache[package_name] = releases
-
-        return self.cache[package_name]

--- a/vulnerabilities/importers/safety_db.py
+++ b/vulnerabilities/importers/safety_db.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# Copyright (c)  nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/vulnerablecode/
 # The VulnerableCode software is licensed under the Apache License version 2.0.
 # Data generated with VulnerableCode require an acknowledgment.
@@ -18,11 +18,12 @@
 #  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
 #  VulnerableCode should be considered or used as legal advice. Consult an Attorney
 #  for any legal advice.
-#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  VulnerableCode is a free software tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 #
 # Data Imported from https://github.com/pyupio/safety-db
-#
+
+import asyncio
 import dataclasses
 import json
 from typing import Any
@@ -74,19 +75,26 @@ class SafetyDbDataSource(DataSource):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._versions = PypiVersionAPI()
+        self._api_response = self._fetch()
+        # validate_schema(self._api_response)
 
     def __enter__(self):
-        self._api_response = self._fetch()
-        validate_schema(self._api_response)
+        self._versions = PypiVersionAPI()
+        self.set_api(self.collect_packages())
 
     @property
     def versions(self):  # quick hack to make it patchable
         return self._versions
 
+    def set_api(self, packages):
+        asyncio.run(self._versions.load_api(packages))
+
     def _fetch(self) -> Mapping[str, Any]:
         with urlopen(self.config.url) as response:
             return json.load(response)
+
+    def collect_packages(self):
+        return {pkg for pkg in self._api_response}
 
     def updated_advisories(self) -> Set[Advisory]:
         advisories = []

--- a/vulnerabilities/importers/safety_db.py
+++ b/vulnerabilities/importers/safety_db.py
@@ -76,7 +76,7 @@ class SafetyDbDataSource(DataSource):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._api_response = self._fetch()
-        # validate_schema(self._api_response)
+        validate_schema(self._api_response)
 
     def __enter__(self):
         self._versions = PypiVersionAPI()

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -1,0 +1,301 @@
+# Copyright (c)  nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an 'AS IS' BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+import asyncio
+from typing import Mapping
+from typing import Set
+from typing import List
+from urllib.error import HTTPError
+from urllib.request import urlopen
+import xml.etree.ElementTree as ET
+
+import requests
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientResponseError
+
+# TODO : 1) Declare a proper blueprint for all VersionAPI classes
+#  2) Use async in every VersionAPI class. This will greatly speed up
+#  the import process.
+
+
+class VersionAPI:
+    def __init__(self, cache: Mapping[str, Set[str]] = None):
+        self.cache = cache or {}
+
+    def get(self, package_name: str) -> Set[str]:
+        return self.cache.get(package_name, set())
+
+
+class LaunchpadVersionAPI(VersionAPI):
+    async def load_api(self, pkg_set):
+        async with ClientSession(raise_for_status=True) as session:
+            await asyncio.gather(
+                *[self.set_api(pkg, session) for pkg in pkg_set if pkg not in self.cache]
+            )
+
+    async def set_api(self, pkg, session):
+        if pkg in self.cache:
+            return
+        url = (
+            "https://api.launchpad.net/1.0/ubuntu/+archive/"
+            "primary?ws.op=getPublishedSources&"
+            "source_name={}&exact_match=true".format(pkg)
+        )
+        try:
+            all_versions = set()
+            while True:
+                response = await session.request(method="GET", url=url)
+                resp_json = await response.json()
+                if resp_json["entries"] == []:
+                    self.cache[pkg] = {}
+                    break
+                for release in resp_json["entries"]:
+                    all_versions.add(release["source_package_version"])
+                if resp_json.get("next_collection_link"):
+                    url = resp_json["next_collection_link"]
+                else:
+                    break
+            self.cache[pkg] = all_versions
+        except (ClientResponseError, asyncio.exceptions.TimeoutError):
+            self.cache[pkg] = {}
+
+
+class PypiVersionAPI(VersionAPI):
+    def get(self, package_name: str) -> Set[str]:
+        package_name = package_name.strip()
+
+        if package_name not in self.cache:
+            releases = set()
+            try:
+                with urlopen(f"https://pypi.org/pypi/{package_name}/json") as response:
+                    json_file = json.load(response)
+                    releases = set(json_file["releases"])
+            except HTTPError as e:
+                if e.code == 404:
+                    # PyPi does not have data about this package
+                    pass
+                else:
+                    raise
+
+            self.cache[package_name] = releases
+
+        return self.cache[package_name]
+
+
+class CratesVersionAPI(VersionAPI):
+    def get(self, package_name: str) -> Set[str]:
+        package_name = package_name.strip()
+
+        if package_name not in self.cache:
+            releases = set()
+
+            try:
+                with urlopen(f"https://crates.io/api/v1/crates/{package_name}") as response:
+                    response = json.load(response)
+                    for version_info in response["versions"]:
+                        releases.add(version_info["num"])
+            except HTTPError as e:
+                if e.code == 404:
+                    pass
+                else:
+                    raise
+
+            self.cache[package_name] = releases
+
+        return self.cache[package_name]
+
+
+class RubyVersionAPI(VersionAPI):
+
+    base_endpt = "https://rubygems.org/api/v1/versions/{}.json"
+
+    def call_api(self, pkg_name) -> List:
+        end_pt = self.base_endpt.format(pkg_name)
+        try:
+            resp = requests.get(end_pt)
+            return resp.json()
+        # this covers 404 alright
+        except JSONDecodeError:
+            return []
+
+    def get_all_version_of_package(self, pkg_name) -> Set[str]:
+        all_versions = set()
+        if self.cache.get(pkg_name):
+            return self.cache.get(pkg_name)
+
+        json_resp = self.call_api(pkg_name)
+        for release in json_resp:
+            all_versions.add(release["number"])
+        self.cache[pkg_name] = all_versions
+        return all_versions
+
+
+class NpmVersionAPI(VersionAPI):
+    def get(self, package_name: str) -> Set[str]:
+        """
+        Returns all versions available for a module
+        """
+        package_name = package_name.strip()
+
+        if package_name not in self.cache:
+            releases = set()
+            try:
+                with urlopen(f"https://registry.npmjs.org/{package_name}") as response:
+                    data = json.load(response)
+                    releases = {v for v in data.get("versions", {})}
+            except HTTPError as e:
+                if e.code == 404:
+                    # NPM registry has no data regarding this package, we skip these
+                    pass
+                else:
+                    raise
+
+            self.cache[package_name] = releases
+
+        return self.cache[package_name]
+
+
+class DebianVersionAPI(VersionAPI):
+    async def load_api(self, pkg_set):
+        # Need to set the headers, because the Debian API upgrades
+        # the connection to HTTP 2.0
+        async with ClientSession(
+            raise_for_status=True, headers={"Connection": "keep-alive"}
+        ) as session:
+            await asyncio.gather(
+                *[self.set_api(pkg, session) for pkg in pkg_set if pkg not in self.cache]
+            )
+
+    async def set_api(self, pkg, session, retry_count=5):
+        if pkg in self.cache:
+            return
+        url = "https://sources.debian.org/api/src/{}".format(pkg)
+        try:
+            all_versions = set()
+            response = await session.request(method="GET", url=url)
+            resp_json = await response.json()
+
+            if resp_json.get("error") or not resp_json.get("versions"):
+                self.cache[pkg] = {}
+                return
+            for release in resp_json["versions"]:
+                all_versions.add(release["version"])
+
+            self.cache[pkg] = all_versions
+        # TODO : Handle ServerDisconnectedError by using some sort of
+        # retry mechanism
+        except (ClientResponseError, asyncio.exceptions.TimeoutError, ServerDisconnectedError):
+            self.cache[pkg] = {}
+
+
+class MavenVersionAPI(VersionAPI):
+    def load_to_api(self, pkg_name: str) -> None:
+        if pkg_name in self.cache:
+            return
+
+        artifact_comps = pkg_name.split(":")
+        endpoint = self.artifact_url(artifact_comps)
+        resp = requests.get(endpoint).content
+
+        try:
+            xml_resp = ET.ElementTree(ET.fromstring(resp.decode("utf-8")))
+            self.cache[pkg_name] = self.extract_versions(xml_resp)
+        except ET.ParseError:
+            self.cache[pkg_name] = set()
+
+    @staticmethod
+    def artifact_url(artifact_comps: List[str]) -> str:
+        base_url = "https://repo.maven.apache.org/maven2/{}"
+        group_id, artifact_id = artifact_comps
+        group_url = group_id.replace(".", "/")
+        suffix = group_url + "/" + artifact_id + "/" + "maven-metadata.xml"
+        endpoint = base_url.format(suffix)
+
+        return endpoint
+
+    @staticmethod
+    def extract_versions(xml_response: ET.ElementTree) -> Set[str]:
+        all_versions = set()
+        for child in xml_response.getroot().iter():
+            if child.tag == "version":
+                all_versions.add(child.text)
+
+        return all_versions
+
+
+class NugetVersionAPI(VersionAPI):
+    def load_to_api(self, pkg_name: str) -> None:
+        if pkg_name in self.cache:
+            return
+        endpoint = self.nuget_url(pkg_name)
+        try:
+            resp = requests.get(endpoint).json()
+        # pkg_name=Microsoft.NETCore.UniversalWindowsPlatform triggers
+        # JSONDecodeError.
+        except json.decoder.JSONDecodeError:
+            self.cache[pkg_name] = set()
+            return
+
+        self.cache[pkg_name] = self.extract_versions(resp)
+
+    @staticmethod
+    def nuget_url(pkg_name: str) -> str:
+        base_url = "https://api.nuget.org/v3/registration5-semver1/{}/index.json"
+        return base_url.format(pkg_name.lower())
+
+    @staticmethod
+    def extract_versions(resp: dict) -> Set[str]:
+        all_versions = set()
+        try:
+            for entry in resp["items"][0]["items"]:
+                all_versions.add(entry["catalogEntry"]["version"])
+        # json response for YamlDotNet.Signed triggers this exception
+        except KeyError:
+            pass
+
+        return all_versions
+
+
+class ComposerVersionAPI(VersionAPI):
+    def load_to_api(self, pkg_name: str) -> None:
+        if pkg_name in self.cache:
+            return
+
+        endpoint = self.composer_url(pkg_name)
+        json_resp = requests.get(endpoint).json()
+        self.cache[pkg_name] = self.extract_versions(json_resp, pkg_name)
+
+    @staticmethod
+    def composer_url(pkg_name: str) -> str:
+        vendor, name = pkg_name.split("/")
+        return f"https://repo.packagist.org/p/{vendor}/{name}.json"
+
+    @staticmethod
+    def extract_versions(resp: dict, pkg_name: str) -> Set[str]:
+        all_versions = resp["packages"][pkg_name].keys()
+        # This filter ensures, that all_versions contains only released versions
+        all_versions = set(filter(lambda x: "dev" not in x, all_versions))
+        # See https://github.com/composer/composer/blob/44a4429978d1b3c6223277b875762b2930e83e8c/doc/articles/versions.md#tags  # nopep8
+        # for explanation of removing 'v'
+        all_versions = set(map(lambda x: x.replace("v", ""), all_versions))
+
+        return all_versions

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -33,10 +33,6 @@ import requests
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientResponseError
 
-# TODO : 1) Declare a proper blueprint for all VersionAPI classes
-#  2) Use async in every VersionAPI class. This will greatly speed up
-#  the import process.
-
 
 class VersionAPI:
     def __init__(self, cache: Mapping[str, Set[str]] = None):

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -224,7 +224,7 @@ class MavenVersionAPI(VersionAPI):
 
     @staticmethod
     def artifact_url(artifact_comps: List[str]) -> str:
-        base_url = "https://repo.maven.apache.org/maven2/{}"
+        base_url = "https://repo1.maven.org/maven2/{}"
         group_id, artifact_id = artifact_comps
         group_url = group_id.replace(".", "/")
         suffix = group_url + "/" + artifact_id + "/" + "maven-metadata.xml"
@@ -292,10 +292,8 @@ class ComposerVersionAPI(VersionAPI):
     @staticmethod
     def extract_versions(resp: dict, pkg_name: str) -> Set[str]:
         all_versions = resp["packages"][pkg_name].keys()
-        # This filter ensures, that all_versions contains only released versions
-        all_versions = set(filter(lambda x: "dev" not in x, all_versions))
+        all_versions = {version.replace("v", "") for version in all_versions if "dev" not in version}  # nopep8
+        # This if statement ensures, that all_versions contains only released versions
         # See https://github.com/composer/composer/blob/44a4429978d1b3c6223277b875762b2930e83e8c/doc/articles/versions.md#tags  # nopep8
         # for explanation of removing 'v'
-        all_versions = set(map(lambda x: x.replace("v", ""), all_versions))
-
         return all_versions

--- a/vulnerabilities/tests/test_debian_oval.py
+++ b/vulnerabilities/tests/test_debian_oval.py
@@ -36,12 +36,12 @@ class TestDebianOvalDataSource(unittest.TestCase):
             batch_size=1, config=data_source_cfg)
 
     @patch(
-        'vulnerabilities.importers.debian_oval.VersionAPI.get',
+        'vulnerabilities.importers.debian_oval.DebianVersionAPI.get',
         return_value={
             '0:1.11.1+dfsg-5+deb7u1',
             '0:0.11.1+dfsg-5+deb7u1',
             '2.3.9'})
-    @patch('vulnerabilities.importers.debian_oval.VersionAPI.load_api', new=mock)
+    @patch('vulnerabilities.importers.debian_oval.DebianVersionAPI.load_api', new=mock)
     def test_get_data_from_xml_doc(self, mock_write):
         expected_data = {
             Advisory(

--- a/vulnerabilities/tests/test_github.py
+++ b/vulnerabilities/tests/test_github.py
@@ -22,7 +22,7 @@
 
 import os
 import json
-import unittest
+from unittest import TestCase
 from unittest.mock import patch
 from unittest.mock import MagicMock
 from unittest.mock import call
@@ -35,9 +35,9 @@ from packageurl import PackageURL
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import Reference
 from vulnerabilities.importers.github import GitHubAPIDataSource
-from vulnerabilities.importers.github import MavenVersionAPI
-from vulnerabilities.importers.github import ComposerVersionAPI
-from vulnerabilities.importers.github import NugetVersionAPI
+from vulnerabilities.package_managers import MavenVersionAPI
+from vulnerabilities.package_managers import NugetVersionAPI
+from vulnerabilities.package_managers import ComposerVersionAPI
 from vulnerabilities.importers.github import GitHubTokenError
 from vulnerabilities.importers.github import query
 
@@ -45,7 +45,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, 'test_data')
 
 
-class TestGitHubAPIDataSource(unittest.TestCase):
+class TestGitHubAPIDataSource(TestCase):
     @classmethod
     def setUpClass(cls):
         data_source_cfg = {
@@ -309,201 +309,3 @@ class TestGitHubAPIDataSource(unittest.TestCase):
             found_result = self.data_src.process_response()
 
         assert expected_result == found_result
-
-
-class TestComposerVersionAPI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.version_api = ComposerVersionAPI()
-        with open(os.path.join(TEST_DATA, 'composer_api', 'cms-core.json')) as f:
-            cls.response = json.load(f)
-
-        cls.expected_versions = {
-            '9.5.3',
-            '8.7.30',
-            '9.3.1',
-            '9.5.1',
-            '9.5.11',
-            '9.5.6',
-            '8.7.18',
-            '8.7.15',
-            '9.4.0',
-            '9.5.7',
-            '8.7.21',
-            '9.5.12',
-            '9.5.14',
-            '8.7.27',
-            '8.7.17',
-            '8.7.9',
-            '10.4.3',
-            '10.0.0',
-            '10.1.0',
-            '9.5.13',
-            '9.5.5',
-            '8.7.22',
-            '8.7.10',
-            '8.7.24',
-            '8.7.13',
-            '8.7.14',
-            '8.7.19',
-            '9.5.17',
-            '9.3.2',
-            '9.5.15',
-            '8.7.8',
-            '9.3.3',
-            '8.7.32',
-            '10.4.0',
-            '10.4.1',
-            '9.5.18',
-            '9.1.0',
-            '9.5.19',
-            '9.5.2',
-            '8.7.26',
-            '8.7.20',
-            '10.2.0',
-            '8.7.31',
-            '8.7.11',
-            '9.2.1',
-            '8.7.25',
-            '9.5.10',
-            '10.2.2',
-            '10.4.2',
-            '9.5.9',
-            '9.2.0',
-            '9.3.0',
-            '9.5.16',
-            '10.3.0',
-            '8.7.7',
-            '10.4.4',
-            '8.7.12',
-            '8.7.29',
-            '10.2.1',
-            '9.5.8',
-            '9.5.4',
-            '9.5.0',
-            '8.7.28',
-            '8.7.23',
-            '9.0.0',
-            '8.7.16',
-        }
-
-    def test_composer_url(self):
-        expected_url = 'https://repo.packagist.org/p/typo3/cms-core.json'
-        found_url = self.version_api.composer_url('typo3/cms-core')
-        assert expected_url == found_url
-
-    def test_extract_versions(self):
-
-        found_versions = self.version_api.extract_versions(
-            self.response, 'typo3/cms-core'
-        )
-        assert found_versions == self.expected_versions
-
-    def test_load_to_api(self):
-
-        assert self.version_api.get('typo3/cms-core') == set()
-
-        mock_response = MagicMock()
-        mock_response.json = lambda: self.response
-
-        with patch(
-            'vulnerabilities.importers.github.requests.get', return_value=mock_response
-        ):
-            self.version_api.load_to_api('typo3/cms-core')
-
-        assert self.version_api.get('typo3/cms-core') == self.expected_versions
-
-
-class TestMavenVersionAPI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.version_api = MavenVersionAPI()
-        with open(os.path.join(TEST_DATA, 'maven_api', 'maven-metadata.xml')) as f:
-            cls.response = ET.parse(f)
-
-    def test_artifact_url(self):
-        eg_comps1 = ['org.apache', 'kafka']
-        eg_comps2 = ['apple.msft.windows.mac.oss', 'exfat-ntfs']
-
-        url1 = self.version_api.artifact_url(eg_comps1)
-        url2 = self.version_api.artifact_url(eg_comps2)
-
-        assert (
-            'https://repo.maven.apache.org/maven2/org/apache/kafka/maven-metadata.xml'
-            == url1
-        )
-        assert (
-            'https://repo.maven.apache.org/maven2'
-            '/apple/msft/windows/mac/oss/exfat-ntfs/maven-metadata.xml' == url2
-        )
-
-    def test_extract_versions(self):
-        expected_versions = {'1.2.2', '1.2.3', '1.3.0'}
-        assert expected_versions == self.version_api.extract_versions(
-            self.response)
-
-    def test_load_to_api(self):
-
-        assert self.version_api.get('org.apache:kafka') == set()
-
-        mock_response = MagicMock()
-        mock_response.content = ET.tostring(self.response.getroot())
-        expected = {'1.2.3', '1.3.0', '1.2.2'}
-
-        with patch(
-            'vulnerabilities.importers.github.requests.get', return_value=mock_response
-        ):
-            self.version_api.load_to_api('org.apache:kafka')
-
-        assert self.version_api.get('org.apache:kafka') == expected
-
-
-class TestNugetVersionAPI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.version_api = NugetVersionAPI()
-        with open(os.path.join(TEST_DATA, 'nuget_api', 'index.json')) as f:
-            cls.response = json.load(f)
-
-        cls.expected_versions = {
-            '0.23.0',
-            '0.24.0',
-            '1.0.0',
-            '1.0.1',
-            '1.0.2',
-            '2.0.0',
-            '2.0.0-preview01',
-            '2.6.0',
-            '2.1.0',
-            '2.2.0',
-            '2.3.0',
-            '2.4.0',
-            '2.5.0',
-            '2.7.0',
-        }
-
-    def test_nuget_url(self):
-        expected_url = (
-            'https://api.nuget.org/v3/registration5-semver1/exfat.ntfs/index.json'
-        )
-        found_url = self.version_api.nuget_url('exfat.ntfs')
-        assert expected_url == found_url
-
-    def test_extract_versions(self):
-
-        found_versions = self.version_api.extract_versions(self.response)
-        assert self.expected_versions == found_versions
-
-    def test_load_to_api(self):
-
-        assert self.version_api.get('exfat.ntfs') == set()
-
-        mock_response = MagicMock()
-        mock_response.json = lambda: self.response
-
-        with patch(
-            'vulnerabilities.importers.github.requests.get', return_value=mock_response
-        ):
-            self.version_api.load_to_api('Exfat.Ntfs')
-
-        assert self.version_api.get('exfat.ntfs') == self.expected_versions

--- a/vulnerabilities/tests/test_github.py
+++ b/vulnerabilities/tests/test_github.py
@@ -130,16 +130,18 @@ class TestGitHubAPIDataSource(TestCase):
 
     def test_set_version_api(self):
 
-        assert getattr(self.data_src, 'version_api', None) is None
+        with patch('vulnerabilities.importers.github.GitHubAPIDataSource.set_api'):
+            with patch('vulnerabilities.importers.github.GitHubAPIDataSource.collect_packages'):
+                assert getattr(self.data_src, 'version_api', None) is None
 
-        self.data_src.set_version_api('MAVEN')
-        assert isinstance(self.data_src.version_api, MavenVersionAPI)
+                self.data_src.set_version_api('MAVEN')
+                assert isinstance(self.data_src.version_api, MavenVersionAPI)
 
-        self.data_src.set_version_api('NUGET')
-        assert isinstance(self.data_src.version_api, NugetVersionAPI)
+                self.data_src.set_version_api('NUGET')
+                assert isinstance(self.data_src.version_api, NugetVersionAPI)
 
-        self.data_src.set_version_api('COMPOSER')
-        assert isinstance(self.data_src.version_api, ComposerVersionAPI)
+                self.data_src.set_version_api('COMPOSER')
+                assert isinstance(self.data_src.version_api, ComposerVersionAPI)
 
     def test_process_name(self):
 
@@ -302,10 +304,8 @@ class TestGitHubAPIDataSource(TestCase):
 
         mock_version_api = MagicMock()
         mock_version_api.get = lambda x: {'1.2.0', '9.0.2'}
-        with patch(
-            'vulnerabilities.importers.github.MavenVersionAPI',
-            return_value=mock_version_api,
-        ):
-            found_result = self.data_src.process_response()
+        with patch('vulnerabilities.importers.github.MavenVersionAPI', return_value=mock_version_api):  # nopep8
+            with patch('vulnerabilities.importers.github.GitHubAPIDataSource.set_api'):
+                found_result = self.data_src.process_response()
 
         assert expected_result == found_result

--- a/vulnerabilities/tests/test_npm.py
+++ b/vulnerabilities/tests/test_npm.py
@@ -81,7 +81,8 @@ class NpmImportTest(TestCase):
         runner = ImportRunner(self.importer, 5)
 
         with patch('vulnerabilities.importers.NpmDataSource.versions', new=MOCK_VERSION_API):
-            runner.run()
+            with patch('vulnerabilities.importers.NpmDataSource.set_api'):
+                runner.run()
 
         assert models.Vulnerability.objects.count() == 3
         assert models.VulnerabilityReference.objects.count() == 3

--- a/vulnerabilities/tests/test_npm.py
+++ b/vulnerabilities/tests/test_npm.py
@@ -31,14 +31,14 @@ from django.test import TestCase
 
 from vulnerabilities import models
 from vulnerabilities.import_runner import ImportRunner
-from vulnerabilities.importers.npm import VersionAPI
+from vulnerabilities.package_managers import NpmVersionAPI
 from vulnerabilities.importers.npm import categorize_versions
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, 'test_data/')
 
 
-MOCK_VERSION_API = VersionAPI(cache={
+MOCK_VERSION_API = NpmVersionAPI(cache={
     'jquery': {'3.4', '3.8'},
     'kerberos': {'0.5.8', '1.2'},
     '@hapi/subtext': {'3.7', '4.1.1', '6.1.3', '7.0.0', '7.0.5'},

--- a/vulnerabilities/tests/test_package_managers.py
+++ b/vulnerabilities/tests/test_package_managers.py
@@ -148,9 +148,9 @@ class TestMavenVersionAPI(TestCase):
         url1 = self.version_api.artifact_url(eg_comps1)
         url2 = self.version_api.artifact_url(eg_comps2)
 
-        assert "https://repo.maven.apache.org/maven2/org/apache/kafka/maven-metadata.xml" == url1
+        assert "https://repo1.maven.org/maven2/org/apache/kafka/maven-metadata.xml" == url1
         assert (
-            "https://repo.maven.apache.org/maven2"
+            "https://repo1.maven.org/maven2"
             "/apple/msft/windows/mac/oss/exfat-ntfs/maven-metadata.xml" == url2
         )
 

--- a/vulnerabilities/tests/test_package_managers.py
+++ b/vulnerabilities/tests/test_package_managers.py
@@ -1,0 +1,219 @@
+# Copyright (c)  nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an 'AS IS' BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
+import os
+import json
+from unittest import TestCase
+from unittest.mock import patch
+from unittest.mock import MagicMock
+import xml.etree.ElementTree as ET
+
+from vulnerabilities.package_managers import ComposerVersionAPI
+from vulnerabilities.package_managers import MavenVersionAPI
+from vulnerabilities.package_managers import NugetVersionAPI
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_DATA = os.path.join(BASE_DIR, "test_data")
+
+
+class TestComposerVersionAPI(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.version_api = ComposerVersionAPI()
+        with open(os.path.join(TEST_DATA, "composer_api", "cms-core.json")) as f:
+            cls.response = json.load(f)
+
+        cls.expected_versions = {
+            "9.5.3",
+            "8.7.30",
+            "9.3.1",
+            "9.5.1",
+            "9.5.11",
+            "9.5.6",
+            "8.7.18",
+            "8.7.15",
+            "9.4.0",
+            "9.5.7",
+            "8.7.21",
+            "9.5.12",
+            "9.5.14",
+            "8.7.27",
+            "8.7.17",
+            "8.7.9",
+            "10.4.3",
+            "10.0.0",
+            "10.1.0",
+            "9.5.13",
+            "9.5.5",
+            "8.7.22",
+            "8.7.10",
+            "8.7.24",
+            "8.7.13",
+            "8.7.14",
+            "8.7.19",
+            "9.5.17",
+            "9.3.2",
+            "9.5.15",
+            "8.7.8",
+            "9.3.3",
+            "8.7.32",
+            "10.4.0",
+            "10.4.1",
+            "9.5.18",
+            "9.1.0",
+            "9.5.19",
+            "9.5.2",
+            "8.7.26",
+            "8.7.20",
+            "10.2.0",
+            "8.7.31",
+            "8.7.11",
+            "9.2.1",
+            "8.7.25",
+            "9.5.10",
+            "10.2.2",
+            "10.4.2",
+            "9.5.9",
+            "9.2.0",
+            "9.3.0",
+            "9.5.16",
+            "10.3.0",
+            "8.7.7",
+            "10.4.4",
+            "8.7.12",
+            "8.7.29",
+            "10.2.1",
+            "9.5.8",
+            "9.5.4",
+            "9.5.0",
+            "8.7.28",
+            "8.7.23",
+            "9.0.0",
+            "8.7.16",
+        }
+
+    def test_composer_url(self):
+        expected_url = "https://repo.packagist.org/p/typo3/cms-core.json"
+        found_url = self.version_api.composer_url("typo3/cms-core")
+        assert expected_url == found_url
+
+    def test_extract_versions(self):
+
+        found_versions = self.version_api.extract_versions(self.response, "typo3/cms-core")
+        assert found_versions == self.expected_versions
+
+    def test_load_to_api(self):
+
+        assert self.version_api.get("typo3/cms-core") == set()
+
+        mock_response = MagicMock()
+        mock_response.json = lambda: self.response
+
+        with patch("vulnerabilities.package_managers.requests.get", return_value=mock_response):
+            self.version_api.load_to_api("typo3/cms-core")
+
+        assert self.version_api.get("typo3/cms-core") == self.expected_versions
+
+
+class TestMavenVersionAPI(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.version_api = MavenVersionAPI()
+        with open(os.path.join(TEST_DATA, "maven_api", "maven-metadata.xml")) as f:
+            cls.response = ET.parse(f)
+
+    def test_artifact_url(self):
+        eg_comps1 = ["org.apache", "kafka"]
+        eg_comps2 = ["apple.msft.windows.mac.oss", "exfat-ntfs"]
+
+        url1 = self.version_api.artifact_url(eg_comps1)
+        url2 = self.version_api.artifact_url(eg_comps2)
+
+        assert "https://repo.maven.apache.org/maven2/org/apache/kafka/maven-metadata.xml" == url1
+        assert (
+            "https://repo.maven.apache.org/maven2"
+            "/apple/msft/windows/mac/oss/exfat-ntfs/maven-metadata.xml" == url2
+        )
+
+    def test_extract_versions(self):
+        expected_versions = {"1.2.2", "1.2.3", "1.3.0"}
+        assert expected_versions == self.version_api.extract_versions(self.response)
+
+    def test_load_to_api(self):
+
+        assert self.version_api.get("org.apache:kafka") == set()
+
+        mock_response = MagicMock()
+        mock_response.content = ET.tostring(self.response.getroot())
+        expected = {"1.2.3", "1.3.0", "1.2.2"}
+
+        with patch("vulnerabilities.package_managers.requests.get", return_value=mock_response):
+            self.version_api.load_to_api("org.apache:kafka")
+
+        assert self.version_api.get("org.apache:kafka") == expected
+
+
+class TestNugetVersionAPI(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.version_api = NugetVersionAPI()
+        with open(os.path.join(TEST_DATA, "nuget_api", "index.json")) as f:
+            cls.response = json.load(f)
+
+        cls.expected_versions = {
+            "0.23.0",
+            "0.24.0",
+            "1.0.0",
+            "1.0.1",
+            "1.0.2",
+            "2.0.0",
+            "2.0.0-preview01",
+            "2.6.0",
+            "2.1.0",
+            "2.2.0",
+            "2.3.0",
+            "2.4.0",
+            "2.5.0",
+            "2.7.0",
+        }
+
+    def test_nuget_url(self):
+        expected_url = "https://api.nuget.org/v3/registration5-semver1/exfat.ntfs/index.json"
+        found_url = self.version_api.nuget_url("exfat.ntfs")
+        assert expected_url == found_url
+
+    def test_extract_versions(self):
+
+        found_versions = self.version_api.extract_versions(self.response)
+        assert self.expected_versions == found_versions
+
+    def test_load_to_api(self):
+
+        assert self.version_api.get("Exfat.Ntfs") == set()
+
+        mock_response = MagicMock()
+        mock_response.json = lambda: self.response
+
+        with patch("vulnerabilities.package_managers.requests.get", return_value=mock_response):
+            self.version_api.load_to_api("Exfat.Ntfs")
+
+        assert self.version_api.get("Exfat.Ntfs") == self.expected_versions

--- a/vulnerabilities/tests/test_ruby.py
+++ b/vulnerabilities/tests/test_ruby.py
@@ -32,6 +32,7 @@ from vulnerabilities.importers.ruby import RubyDataSource
 from vulnerabilities.data_source import GitDataSourceConfiguration
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import Reference
+from vulnerabilities.package_managers import RubyVersionAPI
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -50,8 +51,9 @@ class RubyDataSourceTest(TestCase):
             "repository_url": "https://github.com/rubysec/ruby-advisory-db.git",
         }
         cls.data_src = RubyDataSource(1, config=data_source_cfg)
+        cls.data_src.pkg_manager_api = RubyVersionAPI()
 
-    @patch('vulnerabilities.importers.ruby.RubyVersionAPI.get_all_version_of_package',
+    @patch('vulnerabilities.package_managers.RubyVersionAPI.get',
            return_value={'1.0.0', '1.8.0', '2.0.3'})
     def test_process_file(self, mock_write):
         expected_advisories = {

--- a/vulnerabilities/tests/test_ruby.py
+++ b/vulnerabilities/tests/test_ruby.py
@@ -51,10 +51,8 @@ class RubyDataSourceTest(TestCase):
         }
         cls.data_src = RubyDataSource(1, config=data_source_cfg)
 
-    @patch(
-        "vulnerabilities.importers.ruby.rubyAPI.get_all_version_of_package",
-        return_value={"1.0.0", "1.8.0", "2.0.3"},
-    )
+    @patch('vulnerabilities.importers.ruby.RubyVersionAPI.get_all_version_of_package',
+           return_value={'1.0.0', '1.8.0', '2.0.3'})
     def test_process_file(self, mock_write):
         expected_advisories = {
             Advisory(

--- a/vulnerabilities/tests/test_rust.py
+++ b/vulnerabilities/tests/test_rust.py
@@ -32,8 +32,8 @@ from django.test import TestCase
 
 from vulnerabilities import models
 from vulnerabilities.importers.rust import categorize_versions
-from vulnerabilities.importers.rust import VersionAPI
 from vulnerabilities.import_runner import ImportRunner
+from vulnerabilities.package_managers import CratesVersionAPI
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, 'test_data/')
@@ -165,7 +165,7 @@ class RustImportTest(TestCase):
 
         with patch(
                 'vulnerabilities.importers.RustDataSource.crates_api',
-                new=VersionAPI(cache=self.crates_api_cache)
+                new=CratesVersionAPI(cache=self.crates_api_cache)
         ):
             runner.run(cutoff_date=datetime.datetime(
                 year=2020, month=3, day=18, tzinfo=datetime.timezone.utc))

--- a/vulnerabilities/tests/test_safety_db.py
+++ b/vulnerabilities/tests/test_safety_db.py
@@ -28,14 +28,14 @@ from django.test import TestCase
 
 from vulnerabilities import models
 from vulnerabilities.import_runner import ImportRunner
-from vulnerabilities.importers.safety_db import VersionAPI
+from vulnerabilities.importers.safety_db import PypiVersionAPI
 from vulnerabilities.importers.safety_db import categorize_versions
 from vulnerabilities.data_source import Reference
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, 'test_data/')
 
-MOCK_VERSION_API = VersionAPI(cache={
+MOCK_VERSION_API = PypiVersionAPI(cache={
     'ampache': {'2.0', '5.2.1'},
     'django': {'1.8', '1.4.19', '1.4.22', '1.5.1', '1.6.9', '1.8.14'},
     'zulip': {'2.0', '2.1.1', '2.1.2', '2.1.3'},

--- a/vulnerabilities/tests/test_safety_db.py
+++ b/vulnerabilities/tests/test_safety_db.py
@@ -68,11 +68,9 @@ class SafetyDbImportTest(TestCase):
     def test_import(self):
         runner = ImportRunner(self.importer, 5)
 
-        with patch(
-                'vulnerabilities.importers.SafetyDbDataSource._fetch',
-                return_value=self.mock_response
-        ):
-            runner.run()
+        with patch('vulnerabilities.importers.SafetyDbDataSource._fetch', return_value=self.mock_response):  # nopep8
+            with patch('vulnerabilities.importers.SafetyDbDataSource.set_api'):
+                runner.run()
 
         assert models.Vulnerability.objects.count() == 9
         assert models.VulnerabilityReference.objects.count() == 9

--- a/vulnerabilities/tests/test_ubuntu.py
+++ b/vulnerabilities/tests/test_ubuntu.py
@@ -187,12 +187,12 @@ class TestUbuntuDataSource(unittest.TestCase):
             batch_size=1, config=data_source_cfg)
 
     @patch(
-        'vulnerabilities.importers.ubuntu.VersionAPI.get',
+        'vulnerabilities.importers.ubuntu.LaunchpadVersionAPI.get',
         return_value={
             '0.3.0',
             '0.2.0',
             '2.14-2'})
-    @patch('vulnerabilities.importers.ubuntu.VersionAPI.load_api',new=mock)
+    @patch('vulnerabilities.importers.ubuntu.LaunchpadVersionAPI.load_api',new=mock)
     def test_get_data_from_xml_doc(self, mock_write):
         expected_data = {
             Advisory(


### PR DESCRIPTION
This works by  creating coroutines for all API calls at once in bulk. This cuts the time waiting for server to respond before making another request. 