### PR TITLE
Check date before downloading data

### DIFF
--- a/vulnerabilities/importers/debian.py
+++ b/vulnerabilities/importers/debian.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# Copyright (c) nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/vulnerablecode/
 # The VulnerableCode software is licensed under the Apache License version 2.0.
 # Data generated with VulnerableCode require an acknowledgment.
@@ -18,16 +18,17 @@
 #  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
 #  VulnerableCode should be considered or used as legal advice. Consult an Attorney
 #  for any legal advice.
-#  VulnerableCode is a free software code scanning tool from nexB Inc. and others.
+#  VulnerableCode is a free software tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
 import dataclasses
-import json
+from dateutil import parser as dateparser
 from typing import Any
 from typing import List
 from typing import Mapping
 from typing import Set
-from urllib.request import urlopen
 
+import requests
 from packageurl import PackageURL
 from schema import Optional
 from schema import Or
@@ -84,8 +85,12 @@ class DebianDataSource(DataSource):
     CONFIG_CLASS = DebianConfiguration
 
     def __enter__(self):
-        self._api_response = self._fetch()
-        validate_schema(self._api_response)
+        if self.response_is_new():
+            self._api_response = self._fetch()
+            validate_schema(self._api_response)
+
+        else:
+            self._api_response = {}
 
     def updated_advisories(self) -> Set[Advisory]:
         advisories = []
@@ -96,8 +101,7 @@ class DebianDataSource(DataSource):
         return self.batch_advisories(advisories)
 
     def _fetch(self) -> Mapping[str, Any]:
-        with urlopen(self.config.debian_tracker_url) as response:
-            return json.load(response)
+        return requests.get(self.config.debian_tracker_url).json()
 
     def _parse(self, pkg_name: str, records: Mapping[str, Any]) -> List[Advisory]:
         advisories = []
@@ -146,3 +150,8 @@ class DebianDataSource(DataSource):
             ))
 
         return advisories
+
+    def response_is_new(self):
+        date_str = requests.head(self.config.debian_tracker_url).headers.get('last-modified')
+        last_modified_date = dateparser.parse(date_str)
+        return self.config.last_run_date < last_modified_date


### PR DESCRIPTION
Debian's json security tracker provides a last-modifed date. This PR checks when the data was last imported and compares it with last-modifed date and decides whether to continue or not. 