### PR TITLE
:memo: Update README and web interface to include reference to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ DJANGO_DEV=1 python manage.py runserver
 In your browser access:
 
 ```
-http://127.0.0.1:8000/api/
-http://127.0.0.1:8000/api/packages/?name=<package_name>
+http://127.0.0.1:8000/api/docs
 ```
+For full documentation about API endpoints.

--- a/vulnerabilities/templates/base.html
+++ b/vulnerabilities/templates/base.html
@@ -9,18 +9,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <body class="Site has-background-light">
     <nav class="navbar is-dark is-fixed-top" role="navigation" aria-label="main navigation">
-        <div class="navbar-brand">
-            <a class="navbar-item" href="https://github.com/nexB/vulnerablecode">
-            VulnerableCode Logo
-            </a>
-        </div>
         <div  class="navbar-menu">
             <div class="navbar-start">
                 <a class="navbar-item" href="{% url 'home' %}">
                 Home
                 </a>
-                <a class="navbar-item">
-                Documentation
+                <a class="navbar-item" href="{% url 'schema-swagger-ui' %}">
+                API Docs
                 </a>
                 <div class="navbar-item has-dropdown is-hoverable">
 


### PR DESCRIPTION
We have swagger docs for API. The reference to this docs is added in the README as well as the web interface.

Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>