### PR TITLE
Improve GitHub importer

### DIFF
--- a/vulnerabilities/importer_yielder.py
+++ b/vulnerabilities/importer_yielder.py
@@ -179,7 +179,7 @@ IMPORTER_REGISTRY = [
         'data_source': 'GitHubAPIDataSource',
         'data_source_cfg': {
             'endpoint': 'https://api.github.com/graphql',
-            'ecosystems': ['MAVEN', 'NUGET', 'COMPOSER']
+            'ecosystems': ['MAVEN', 'NUGET', 'COMPOSER', 'PIP', 'RUBYGEMS']
         }
     },
     {

--- a/vulnerabilities/importers/github.py
+++ b/vulnerabilities/importers/github.py
@@ -97,14 +97,6 @@ class GitHubAPIDataSource(DataSource):
         except KeyError:
             raise GitHubTokenError("Environment variable GH_TOKEN is missing")
 
-        self.ecosytem_type = {
-            "RUBYGEMS": "gem",
-            "NUGET": "nuget",
-            "PIP": "pypi",
-            "MAVEN": "maven",
-            "COMPOSER": "composer",
-        }
-
     def __enter__(self):
         self.advisories = self.fetch()
 
@@ -177,7 +169,7 @@ class GitHubAPIDataSource(DataSource):
         adv_list = []
         for ecosystem in self.advisories:
             self.set_version_api(ecosystem)
-            pkg_type = self.ecosytem_type[ecosystem]
+            pkg_type = self.version_api.package_type
             for resp_page in self.advisories[ecosystem]:
                 for adv in resp_page["data"]["securityVulnerabilities"]["edges"]:
                     name = adv["node"]["package"]["name"]

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -41,6 +41,9 @@ class VersionAPI:
 
 
 class LaunchpadVersionAPI(VersionAPI):
+
+    package_type = "deb"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -75,6 +78,9 @@ class LaunchpadVersionAPI(VersionAPI):
 
 
 class PypiVersionAPI(VersionAPI):
+
+    package_type = "pypi"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -96,6 +102,9 @@ class PypiVersionAPI(VersionAPI):
 
 
 class CratesVersionAPI(VersionAPI):
+
+    package_type = "cargo"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -114,6 +123,9 @@ class CratesVersionAPI(VersionAPI):
 
 
 class RubyVersionAPI(VersionAPI):
+
+    package_type = "gem"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -135,6 +147,9 @@ class RubyVersionAPI(VersionAPI):
 
 
 class NpmVersionAPI(VersionAPI):
+
+    package_type = "npm"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -156,6 +171,9 @@ class NpmVersionAPI(VersionAPI):
 
 
 class DebianVersionAPI(VersionAPI):
+
+    package_type = "deb"
+
     async def load_api(self, pkg_set):
         # Need to set the headers, because the Debian API upgrades
         # the connection to HTTP 2.0
@@ -189,6 +207,9 @@ class DebianVersionAPI(VersionAPI):
 
 
 class MavenVersionAPI(VersionAPI):
+
+    package_type = "maven"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -242,6 +263,9 @@ class MavenVersionAPI(VersionAPI):
 
 
 class NugetVersionAPI(VersionAPI):
+
+    package_type = "nuget"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -274,6 +298,9 @@ class NugetVersionAPI(VersionAPI):
 
 
 class ComposerVersionAPI(VersionAPI):
+
+    package_type = "composer"
+
     async def load_api(self, pkg_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(
@@ -304,6 +331,9 @@ class ComposerVersionAPI(VersionAPI):
 
 
 class GitHubTagsAPI(VersionAPI):
+
+    package_type = "github"
+
     async def load_api(self, repo_set):
         async with ClientSession(raise_for_status=True) as session:
             await asyncio.gather(

--- a/vulnerabilities/tests/test_github.py
+++ b/vulnerabilities/tests/test_github.py
@@ -303,6 +303,7 @@ class TestGitHubAPIDataSource(TestCase):
         ]
 
         mock_version_api = MagicMock()
+        mock_version_api.package_type = "maven"
         mock_version_api.get = lambda x: {'1.2.0', '9.0.2'}
         with patch('vulnerabilities.importers.github.MavenVersionAPI', return_value=mock_version_api):  # nopep8
             with patch('vulnerabilities.importers.github.GitHubAPIDataSource.set_api'):


### PR DESCRIPTION
* The github importer used to abandon a vulnerability if
  the affected package had invalid name. This PR changes that
  behaviour to instead  skip the package and import the vulnerability

* This commit also enables github importer to import vulnerabilities for python
  and rubygems packages. This is crucial since we can't  use safetydb