### PR TITLE
Use drf-spectacular instead of  drf-yasg for API docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Django==3.0.7
 django-filter==2.2.0
 djangorestframework==3.11.0
 django-widget-tweaks==1.4.8
-drf-yasg==1.17.1
+drf-spectacular==0.13.0
 gunicorn==19.7.1
 importlib-metadata==1.3.0
 ipython==7.13.0

--- a/vulnerabilities/templates/base.html
+++ b/vulnerabilities/templates/base.html
@@ -14,7 +14,7 @@
                 <a class="navbar-item" href="{% url 'home' %}">
                 Home
                 </a>
-                <a class="navbar-item" href="{% url 'schema-swagger-ui' %}">
+                <a class="navbar-item" href="{% url 'swagger-ui' %}">
                 API Docs
                 </a>
                 <div class="navbar-item has-dropdown is-hoverable">

--- a/vulnerablecode/settings.py
+++ b/vulnerablecode/settings.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'django_filters',
     'widget_tweaks',
-    'drf_yasg',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -159,7 +159,14 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
+
+SPECTACULAR_SETTINGS = {
+    'SERVE_INCLUDE_SCHEMA': False,
+    'TITLE': "VulnerableCode API"
+}
+# TODO: Specify the license for the API here. 
 
 
 # Set `DJANGO_DEV=1` in env to enable dev mode

--- a/vulnerablecode/urls.py
+++ b/vulnerablecode/urls.py
@@ -23,10 +23,10 @@
 
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework import permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
 from rest_framework.routers import DefaultRouter
+
 
 from vulnerabilities.api import PackageViewSet
 from vulnerabilities.api import VulnerabilityViewSet
@@ -41,12 +41,6 @@ from vulnerabilities.views import VulnerabilitySearchView
 from vulnerabilities.views import VulnerabilityCreate
 from vulnerabilities.views import VulnerabilityReferenceCreate
 
-schema_view = get_schema_view(
-    openapi.Info(title="VulnerableCode API", default_version="v1"),
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-)
-
 api_router = DefaultRouter()
 api_router.register(r"packages", PackageViewSet)
 # `DefaultRouter` requires `basename` when registering viewsets which don't
@@ -56,6 +50,8 @@ api_router.register(r"vulnerabilities", VulnerabilityViewSet, basename="vulnerab
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(), name='swagger-ui'),
     path("packages/search", PackageSearchView.as_view(), name="package_search"),
     path("packages/<int:pk>", PackageUpdate.as_view(), name="package_view"),
     path("vulnerabilities/<int:pk>", VulnerabilityDetails.as_view(), name="vulnerability_view"),
@@ -88,6 +84,5 @@ urlpatterns = [
         name="vulnerability_reference_create",
     ),
     path("", HomePage.as_view(), name="home"),
-    path(r"api/", include(api_router.urls)),
-    path(r"api/docs", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
+    path(r"api/", include(api_router.urls))
 ]


### PR DESCRIPTION
drf-yasg is not maintained and does not support OpenAPI 3.0.

Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>