### PR TITLE
Improve Ubuntu OVAL importer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,5 @@ addopts =
     -rfEsxXw
     --strict
     --ignore setup.py
+    --ignore vulnerabilities/lib_oval.py
     --doctest-modules

--- a/vulnerabilities/data_source.py
+++ b/vulnerabilities/data_source.py
@@ -466,29 +466,48 @@ class OvalDataSource(DataSource):
 
     def _fetch(self) -> Tuple[Mapping, Iterable[ET.ElementTree]]:
         """
-        This method  contains logic to fetch OVAL files and yield them into
-        a tuple of file's metadata and it's ET.ElementTree.
+        Return a two-tuple of ({mapping of Package URL data}, it's ET.ElementTree)
         Subclasses must implement this method.
 
-        Note: Mapping MUST INCLUDE "type" key. Example values of Mapping
-              {"type":"deb","qualifiers":{"distro":"buster"} }
+        Note:  Package URL data MUST INCLUDE a Package URL "type" key so
+        implement _fetch() accordingly.
+        For example::
 
+              {"type":"deb","qualifiers":{"distro":"buster"} }
         """
+        # TODO: enforce that we receive the proper data here
         raise NotImplementedError
 
     def updated_advisories(self) -> List[Advisory]:
-        """
-        Note: metadata MUST INCLUDE "type" key, implement _fetch accordingly.
-        """
-        for metadata, oval_file in self._fetch():
+        for purl_data, oval_etree in self._fetch():
+            if 'type' not in purl_data:
+                ets = (oval_etree and ET.tostring(oval_etree)) or 'NO DATA'
+                msg = (
+                    "Failed to get updated_advisories for Ubuntu: purl_data is "
+                    f"missing a package type {purl_data!r}\n"
+                    f"with OVAL XML:\n"
+                    f"{ets}\n"
+                    f"... continuing..."
+                )
+                print(msg)
+                logger.error(msg)
+                continue
+
             try:
-                oval_data = self.get_data_from_xml_doc(oval_file, metadata)
+                oval_data = self.get_data_from_xml_doc(oval_etree, purl_data)
                 yield oval_data
             except Exception:
-                logger.error(
-                    f"Failed to get updated_advisories: {oval_file!r} "
-                    "with {metadata!r}:\n" + traceback.format_exc()
+                ets = (oval_etree and ET.tostring(oval_etree)) or 'NO DATA'
+                tb = traceback.format_exc()
+                msg = (
+                    f"Failed to get updated_advisories for Ubuntu:"
+                    f"with {purl_data!r}\n"
+                    f"and with OVAL XML:\n"
+                    f"{ets}\n{tb}\n"
+                    f"... continuing..."
                 )
+                print(msg)
+                logger.error(msg)
                 continue
 
     def set_api(self, all_pkgs: Iterable[str]):
@@ -506,34 +525,66 @@ class OvalDataSource(DataSource):
 
     def get_data_from_xml_doc(self, xml_doc: ET.ElementTree, pkg_metadata={}) -> List[Advisory]:
         """
-        The orchestration method of the OvalDataSource. This method breaks an OVAL xml
-        ElementTree into a list of `Advisory`.
+        The orchestration method of the OvalDataSource. This method breaks an
+        OVAL xml ElementTree into a list of `Advisory`.
 
-        Note: pkg_metadata MUST INCLUDE "type" key. Example value of pkg_metadata,
+        Note: pkg_metadata is a mapping of Package URL data that MUST INCLUDE
+        "type" key.
+
+        Example value of pkg_metadata:
               {"type":"deb","qualifiers":{"distro":"buster"} }
         """
+        if 'type' not in pkg_metadata:
+            ets = xml_doc and ET.tostring(xml_doc) or 'NO DATA'
+            msg = (
+                "Failed to get_data_from_xml_doc: pkg_metadata is "
+                f"missing a package type {pkg_metadata!r}\n"
+                f"with OVAL XML:\n"
+                f"{ets}"
+            )
+            print(msg)
+            logger.error(msg)
+            raise Exception(msg)
+
         all_adv = []
         oval_doc = OvalParser(self.translations, xml_doc)
-        raw_data = oval_doc.get_data()
+        try:
+            raw_data = oval_doc.get_data()
+        except Exception:
+            ets = xml_doc and ET.tostring(xml_doc) or 'NO DATA'
+            tb = traceback.format_exc()
+            msg = (
+                f"Failed to get_data_from_xml_doc:"
+                f"with {pkg_metadata!r}\n"
+                f"and with OVAL XML:\n"
+                f"{ets}\n{tb}"
+            )
+            print(msg)
+            logger.error(msg)
+            raise Exception(msg)
+
         all_pkgs = self._collect_pkgs(raw_data)
         self.set_api(all_pkgs)
-        for definition_data in raw_data:  # definition_data -> Advisory
 
-            # These fields are definition level, i.e common for all
-            # elements connected/linked to an OvalDefinition
-            vuln_id = definition_data["vuln_id"]
-            description = definition_data["description"]
+        # convert definition_data to Advisory objects
+        for definition_data in raw_data:
+            # These fields are definition level, i.e common for all elements
+            # connected/linked to an OvalDefinition
+            vuln_id = definition_data['vuln_id']
+            description = definition_data['description']
             affected_purls = set()
             safe_purls = set()
-            references = [Reference(url=url) for url in definition_data["reference_urls"]]
-
-            for test_data in definition_data["test_data"]:
-                for package in test_data["package_list"]:
+            references = [Reference(url=url) for url in definition_data['reference_urls']]
+            for test_data in definition_data['test_data']:
+                for package in test_data['package_list']:
                     pkg_name = package
                     if package and len(pkg_name) >= 50:
                         continue
-                    aff_ver_range = test_data["version_ranges"]
+                    aff_ver_range = test_data['version_ranges'] or set()
                     all_versions = self.pkg_manager_api.get(package)
+
+                    # FIXME: what is this 50 DB limit? that's too small for versions
+                    # FIXME: we should not drop data this way
                     # This filter is for filtering out long versions.
                     # 50 is limit because that's what db permits atm.
                     all_versions = set(filter(lambda x: len(x) < 50, all_versions))
@@ -544,13 +595,17 @@ class OvalDataSource(DataSource):
 
                     for version in affected_versions:
                         pkg_url = self.create_purl(
-                            pkg_name=pkg_name, pkg_version=version, pkg_data=pkg_metadata
+                            pkg_name=pkg_name,
+                            pkg_version=version,
+                            pkg_data=pkg_metadata,
                         )
                         affected_purls.add(pkg_url)
 
                     for version in safe_versions:
                         pkg_url = self.create_purl(
-                            pkg_name=pkg_name, pkg_version=version, pkg_data=pkg_metadata
+                            pkg_name=pkg_name,
+                            pkg_version=version,
+                            pkg_data=pkg_metadata,
                         )
                         safe_purls.add(pkg_url)
 

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -23,9 +23,9 @@
 import json
 import re
 
-import yaml
 import requests
 import toml
+import yaml
 
 # TODO add logging here
 
@@ -50,6 +50,13 @@ def fetch_yaml(url):
     return yaml.safe_load(response.content)
 
 
+# FIXME: this is NOT how etags work .
+# We should instead send the proper HTTP header
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+# and integrate this finely in the processing as this typically needs to use
+# streaming=True requests, and proper handling of the HTTP return code
+# In all cases this ends up being a single request, not a HEADD followed
+# by another real request
 def create_etag(data_src, url, etag_key):
     """
     Etags are like hashes of web responses. For a data source `data_src`,

--- a/vulnerabilities/importer_yielder.py
+++ b/vulnerabilities/importer_yielder.py
@@ -93,7 +93,7 @@ IMPORTER_REGISTRY = [
         'data_source': 'UbuntuDataSource',
         'data_source_cfg': {
             'etags': {},
-            'releases': ['xenial'],
+            'releases': ['bionic', 'trusty', 'focal', 'eoan', 'xenial'],
         },
     },
     {

--- a/vulnerabilities/importer_yielder.py
+++ b/vulnerabilities/importer_yielder.py
@@ -93,7 +93,7 @@ IMPORTER_REGISTRY = [
         'data_source': 'UbuntuDataSource',
         'data_source_cfg': {
             'etags': {},
-            'releases': ['bionic', 'trusty', 'focal', 'eoan', 'xenial'],
+            'releases': ['xenial'],
         },
     },
     {

--- a/vulnerabilities/importers/ubuntu.py
+++ b/vulnerabilities/importers/ubuntu.py
@@ -58,9 +58,10 @@ class UbuntuDataSource(OvalDataSource):
         self.pkg_manager_api = LaunchpadVersionAPI()
 
     def _fetch(self):
+        base_url = 'https://people.canonical.com/~ubuntu-security/oval'
         releases = self.config.releases
         for i, release in enumerate(releases, 1):
-            file_url = f"https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.{release}.cve.oval.xml.bz2"  # nopep8
+            file_url = f"{base_url}/com.ubuntu.{release}.cve.oval.xml.bz2"  # nopep8
 #             if not create_etag(data_src=self, url=file_url, etag_key="ETag"):
 #                 print(f"Ubuntu Oval Etag not changed, not re-fetching: {file_url}")
 #                 continue
@@ -77,7 +78,7 @@ class UbuntuDataSource(OvalDataSource):
                 ET.ElementTree(ET.fromstring(extracted.decode("utf-8"))),
             )
 
-        print(f"Fetched {i} Ubuntu Oval releases https://people.canonical.com/~ubuntu-security/oval/")  # nopep8
+        print(f"Fetched {i} Ubuntu Oval releases from {base_url}")
 
     def set_api(self, packages):
         asyncio.run(self.pkg_manager_api.load_api(packages))

--- a/vulnerabilities/importers/ubuntu.py
+++ b/vulnerabilities/importers/ubuntu.py
@@ -59,21 +59,25 @@ class UbuntuDataSource(OvalDataSource):
 
     def _fetch(self):
         releases = self.config.releases
-        for release in releases:
+        for i, release in enumerate(releases, 1):
             file_url = f"https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.{release}.cve.oval.xml.bz2"  # nopep8
-            if not create_etag(data_src=self, url=file_url, etag_key="ETag"):
+#             if not create_etag(data_src=self, url=file_url, etag_key="ETag"):
+#                 print(f"Ubuntu Oval Etag not changed, not re-fetching: {file_url}")
+#                 continue
+
+            print(f"Fetching Ubuntu Oval: {file_url}")
+            response = requests.get(file_url)
+            if response.status_code != requests.codes.ok:
+                print(f"Failed to fetch Ubuntu Oval: HTTP {response.status_code} : {file_url}")
                 continue
-            resp = requests.get(file_url)
-            extracted = bz2.decompress(resp.content)
+
+            extracted = bz2.decompress(response.content)
             yield (
                 {"type": "deb", "namespace": "ubuntu"},
                 ET.ElementTree(ET.fromstring(extracted.decode("utf-8"))),
             )
-        # In case every file is latest, _fetch won't yield anything(due to checking for new etags),
-        # this would return None to added_advisories
-        # which will cause error, hence this
-        # function return an empty list
-        return []
+
+        print(f"Fetched {i} Ubuntu Oval releases https://people.canonical.com/~ubuntu-security/oval/")  # nopep8
 
     def set_api(self, packages):
         asyncio.run(self.pkg_manager_api.load_api(packages))

--- a/vulnerabilities/lib_oval.py
+++ b/vulnerabilities/lib_oval.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env/ python3
-# Copyright© 2010 United States Government. All Rights Reserved.
+# Copyright (c) 2010 United States Government. All Rights Reserved.
 
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# * Neither the name of the Center for Internet Security, Inc. (CIS) nor the names
+# of its contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
 
-# * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-# * Neither the name of the Center for Internet Security, Inc. (CIS) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER, CIS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER, CIS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER, CIS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER, CIS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Library to simplify working with the OVAL XML structure
 
 
@@ -39,29 +58,29 @@ Available exceptions:
 
 1. Create an OvalDocument:
 
-    >> tree = ElementTree()
-    >> tree.parse("OvalTest.xml")
-    >> document = OvalDocument(tree)
+    >>> tree = ElementTree()
+    >>> tree.parse("OvalTest.xml")
+    >>> document = OvalDocument(tree)
 
 2. Find an oval element within the loaded document:
 
-    >> element = document.getElementByID("oval:org.mitre.oval:def:22382")
-    >> if element is not None:
-    >>    ....
+    >>> element = document.getElementByID("oval:org.mitre.oval:def:22382")
+    >>> if element is not None:
+    >>>    ....
 
 3. Read an XML file with a single OVAL Definition (error checking omitted for brevity):
 
-    >> tree = ElementTree()    
-    >> tree.parse('test-definition.xml')
-    >> root = tree.getroot()    
-    >> definition = lib_oval.OvalDefinition(root)
+    >>> tree = ElementTree()    
+    >>> tree.parse('test-definition.xml')
+    >>> root = tree.getroot()    
+    >>> definition = lib_oval.OvalDefinition(root)
     
 4. Change information in the definition from #3 and write the changes
 
-    >> meta = definition.getMetadata()
-    >> repo = meta.getOvalRepositoryInformation()
-    >> repo.setMinimumSchemaVersion("5.9")
-    >> tree.write("outfilename.xml", UTF-8", True)
+    >>> meta = definition.getMetadata()
+    >>> repo = meta.getOvalRepositoryInformation()
+    >>> repo.setMinimumSchemaVersion("5.9")
+    >>> tree.write("outfilename.xml", UTF-8", True)
         
 
 

--- a/vulnerabilities/lib_oval.py
+++ b/vulnerabilities/lib_oval.py
@@ -27,71 +27,71 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Library to simplify working with the OVAL XML structure
+"""Library to simplify working with the OVAL XML structure
 
 
-# Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
-
-
-
-# Available classes:
-#     - OvalDocument:    operations at the OVAL document level, such as reading in an existing OVAL document from
-# file, creating a new one, finding or adding OVAL elements
-#     - OvalElement:    the base class for OVAL elements.  Implements a few common methods inherited by the
-# subclasses for definition, test, state, object, and variable
-#     - OvalDefinition:    a type of OVAL element with certain attributes available.  Additional classes used by the OvalDefinition class:
-#         - OvalMetadata:    the metadata associated with a definition, which includes the definition title and description.  Metadata also contains:
-#             - OvalAffected:    The family and platforms affected by this definition
-#             - OvalRepositoryInformation:    Additional information added by the OVAL repository
-#     - OvalTest:    for working with OVAL test elements
-#     - OvalObject:    for working with OVAL object elements
-#     - OvalState:    for working with OVAL state elements
-#     - OvalVariable:    for working with OVAL variable elements
+Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
 
 
 
-# Available exceptions:
-#     - None at this time
+Available classes:
+    - OvalDocument:    operations at the OVAL document level, such as reading in an existing OVAL document from
+file, creating a new one, finding or adding OVAL elements
+    - OvalElement:    the base class for OVAL elements.  Implements a few common methods inherited by the
+subclasses for definition, test, state, object, and variable
+    - OvalDefinition:    a type of OVAL element with certain attributes available.  Additional classes used by the OvalDefinition class:
+        - OvalMetadata:    the metadata associated with a definition, which includes the definition title and description.  Metadata also contains:
+            - OvalAffected:    The family and platforms affected by this definition
+            - OvalRepositoryInformation:    Additional information added by the OVAL repository
+    - OvalTest:    for working with OVAL test elements
+    - OvalObject:    for working with OVAL object elements
+    - OvalState:    for working with OVAL state elements
+    - OvalVariable:    for working with OVAL variable elements
+
+
+
+Available exceptions:
+    - None at this time
     
     
-# :Usage:
+:Usage:
 
-# 1. Create an OvalDocument:
+1. Create an OvalDocument:
 
-#     >>> tree = ElementTree()
-#     >>> tree.parse("OvalTest.xml")
-#     >>> document = OvalDocument(tree)
+    >>> tree = ElementTree()
+    >>> tree.parse("OvalTest.xml")
+    >>> document = OvalDocument(tree)
 
-# 2. Find an oval element within the loaded document:
+2. Find an oval element within the loaded document:
 
-#     >>> element = document.getElementByID("oval:org.mitre.oval:def:22382")
-#     >>> if element is not None:
-#     >>>    ....
+    >>> element = document.getElementByID("oval:org.mitre.oval:def:22382")
+    >>> if element is not None:
+    >>>    ....
 
-# 3. Read an XML file with a single OVAL Definition (error checking omitted for brevity):
+3. Read an XML file with a single OVAL Definition (error checking omitted for brevity):
 
-#     >>> tree = ElementTree()    
-#     >>> tree.parse('test-definition.xml')
-#     >>> root = tree.getroot()    
-#     >>> definition = lib_oval.OvalDefinition(root)
+    >>> tree = ElementTree()    
+    >>> tree.parse('test-definition.xml')
+    >>> root = tree.getroot()    
+    >>> definition = lib_oval.OvalDefinition(root)
     
-# 4. Change information in the definition from #3 and write the changes
+4. Change information in the definition from #3 and write the changes
 
-#     >>> meta = definition.getMetadata()
-#     >>> repo = meta.getOvalRepositoryInformation()
-#     >>> repo.setMinimumSchemaVersion("5.9")
-#     >>> tree.write("outfilename.xml", UTF-8", True)
+    >>> meta = definition.getMetadata()
+    >>> repo = meta.getOvalRepositoryInformation()
+    >>> repo.setMinimumSchemaVersion("5.9")
+    >>> tree.write("outfilename.xml", UTF-8", True)
         
 
 
   
 
-# TODO:
-#     - Add exceptions that give more detail about why a value of None is sometimes returned
-#     - Expand use of find() to allow for the possibility that the XML document is not using namespaces
-#     - Lots of pydoc to be added
-#     - Redo getter/setter for OvalRepository status elements.
-
+TODO:
+    - Add exceptions that give more detail about why a value of None is sometimes returned
+    - Expand use of find() to allow for the possibility that the XML document is not using namespaces
+    - Lots of pydoc to be added
+    - Redo getter/setter for OvalRepository status elements.
+"""
 
 import os, xml.etree
 from xml.etree import ElementTree

--- a/vulnerabilities/lib_oval.py
+++ b/vulnerabilities/lib_oval.py
@@ -27,71 +27,71 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Library to simplify working with the OVAL XML structure
+# Library to simplify working with the OVAL XML structure
 
 
-Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
-
-
-
-Available classes:
-    - OvalDocument:    operations at the OVAL document level, such as reading in an existing OVAL document from
-file, creating a new one, finding or adding OVAL elements
-    - OvalElement:    the base class for OVAL elements.  Implements a few common methods inherited by the
-subclasses for definition, test, state, object, and variable
-    - OvalDefinition:    a type of OVAL element with certain attributes available.  Additional classes used by the OvalDefinition class:
-        - OvalMetadata:    the metadata associated with a definition, which includes the definition title and description.  Metadata also contains:
-            - OvalAffected:    The family and platforms affected by this definition
-            - OvalRepositoryInformation:    Additional information added by the OVAL repository
-    - OvalTest:    for working with OVAL test elements
-    - OvalObject:    for working with OVAL object elements
-    - OvalState:    for working with OVAL state elements
-    - OvalVariable:    for working with OVAL variable elements
+# Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
 
 
 
-Available exceptions:
-    - None at this time
+# Available classes:
+#     - OvalDocument:    operations at the OVAL document level, such as reading in an existing OVAL document from
+# file, creating a new one, finding or adding OVAL elements
+#     - OvalElement:    the base class for OVAL elements.  Implements a few common methods inherited by the
+# subclasses for definition, test, state, object, and variable
+#     - OvalDefinition:    a type of OVAL element with certain attributes available.  Additional classes used by the OvalDefinition class:
+#         - OvalMetadata:    the metadata associated with a definition, which includes the definition title and description.  Metadata also contains:
+#             - OvalAffected:    The family and platforms affected by this definition
+#             - OvalRepositoryInformation:    Additional information added by the OVAL repository
+#     - OvalTest:    for working with OVAL test elements
+#     - OvalObject:    for working with OVAL object elements
+#     - OvalState:    for working with OVAL state elements
+#     - OvalVariable:    for working with OVAL variable elements
+
+
+
+# Available exceptions:
+#     - None at this time
     
     
-:Usage:
+# :Usage:
 
-1. Create an OvalDocument:
+# 1. Create an OvalDocument:
 
-    >>> tree = ElementTree()
-    >>> tree.parse("OvalTest.xml")
-    >>> document = OvalDocument(tree)
+#     >>> tree = ElementTree()
+#     >>> tree.parse("OvalTest.xml")
+#     >>> document = OvalDocument(tree)
 
-2. Find an oval element within the loaded document:
+# 2. Find an oval element within the loaded document:
 
-    >>> element = document.getElementByID("oval:org.mitre.oval:def:22382")
-    >>> if element is not None:
-    >>>    ....
+#     >>> element = document.getElementByID("oval:org.mitre.oval:def:22382")
+#     >>> if element is not None:
+#     >>>    ....
 
-3. Read an XML file with a single OVAL Definition (error checking omitted for brevity):
+# 3. Read an XML file with a single OVAL Definition (error checking omitted for brevity):
 
-    >>> tree = ElementTree()    
-    >>> tree.parse('test-definition.xml')
-    >>> root = tree.getroot()    
-    >>> definition = lib_oval.OvalDefinition(root)
+#     >>> tree = ElementTree()    
+#     >>> tree.parse('test-definition.xml')
+#     >>> root = tree.getroot()    
+#     >>> definition = lib_oval.OvalDefinition(root)
     
-4. Change information in the definition from #3 and write the changes
+# 4. Change information in the definition from #3 and write the changes
 
-    >>> meta = definition.getMetadata()
-    >>> repo = meta.getOvalRepositoryInformation()
-    >>> repo.setMinimumSchemaVersion("5.9")
-    >>> tree.write("outfilename.xml", UTF-8", True)
+#     >>> meta = definition.getMetadata()
+#     >>> repo = meta.getOvalRepositoryInformation()
+#     >>> repo.setMinimumSchemaVersion("5.9")
+#     >>> tree.write("outfilename.xml", UTF-8", True)
         
 
 
   
 
-TODO:
-    - Add exceptions that give more detail about why a value of None is sometimes returned
-    - Expand use of find() to allow for the possibility that the XML document is not using namespaces
-    - Lots of pydoc to be added
-    - Redo getter/setter for OvalRepository status elements.
-"""
+# TODO:
+#     - Add exceptions that give more detail about why a value of None is sometimes returned
+#     - Expand use of find() to allow for the possibility that the XML document is not using namespaces
+#     - Lots of pydoc to be added
+#     - Redo getter/setter for OvalRepository status elements.
+
 
 import os, xml.etree
 from xml.etree import ElementTree

--- a/vulnerabilities/lib_oval.py.ABOUT
+++ b/vulnerabilities/lib_oval.py.ABOUT
@@ -1,14 +1,12 @@
 about_resource: lib_oval.py
-version: 6aaae0
-download_url: https://raw.githubusercontent.com/CISecurity/OVALRepo/6aaae00876ec716927e0ae5b9ccfa12f310427a0/scripts/lib_oval.py
-
-name: OVALRepo - lib_oval
+version: e74da20d7c1de91c098c564ce65d6b93656eb86f
+download_url: https://raw.githubusercontent.com/CISecurity/OVALRepo/e74da20d7c1de91c098c564ce65d6b93656eb86f/scripts/lib_oval.py
+package_url: pkg:github/CISecurity/OVALRepo@e74da20d7c1de91c098c564ce65d6b93656eb86f#scripts/lib_oval.py
 homepage_url: https://github.com/CISecurity/OVALRepo
 owner: Center for Internet Security
 author: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
 notes: This a single file extracted from OVALRepo that parses OVAL files.
 
-license: bsd-new
-license_file: lib_oval.py.LICENSE
-
 copyright: Copyright (c) 2010 United States Government. All Rights Reserved.
+license_expression: bsd-new
+license_file: lib_oval.py.LICENSE

--- a/vulnerabilities/lib_oval.py.LICENSE
+++ b/vulnerabilities/lib_oval.py.LICENSE
@@ -1,9 +1,26 @@
-Copyright© 2010 United States Government. All Rights Reserved.
+Copyright (c) 2010 United States Government. All Rights Reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-    Neither the name of the Center for Internet Security, Inc. (CIS) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER, CIS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER, CIS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    Neither the name of the Center for Internet Security, Inc. (CIS) nor the
+    names of its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER, CIS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER, CIS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vulnerabilities/oval_parser.py
+++ b/vulnerabilities/oval_parser.py
@@ -155,7 +155,10 @@ class OvalParser:
                 return RangeSpecifier(version_range)
             except Exception:
                 # FIXME: we should not continue
-                print(f"Failed to process invalid version_range in OvalState: {version_range}...continuing")  # nopep8
+                print(
+                    f"get_versionsrngs_from_state: Failed to process invalid "
+                    f"OvalState version range: {version_range}...continuing"
+                )
 
     @staticmethod
     def get_urls_from_definition(definition: OvalDefinition) -> Set[str]:

--- a/vulnerabilities/oval_parser.py
+++ b/vulnerabilities/oval_parser.py
@@ -146,18 +146,21 @@ class OvalParser:
             if not version:
                 continue
             version_range = operand + version
-            try:
-                return RangeSpecifier(version_range)
-            except Exception:
-                try:
-                    version_range = version_range.replace(".x", "")
-                    return RangeSpecifier(version_range)
-                except Exception:
-                    # FIXME: we should not continue
-                    print(
-                        f"get_version_ranges_from_state: Failed to process invalid "
-                        f"OvalState version range: {version_range}...continuing"
-                    )
+            version_range = version_range.replace("only", "").strip()
+
+            # 0: is default epoch, remove it
+            version_range = version_range.replace("0:", "").strip()
+            x_version_ranges = {
+                "<2.0.x": "2.0.x",
+                "<3.x": "3.x",
+                "<4.6.x": "4.6.x",
+                "<8.0.x": "8.0.x",
+                "<8.x": "8.x",
+            }
+            if version_range in x_version_ranges:
+                version_range = x_version_ranges[version_range]
+
+            return RangeSpecifier(version_range)
 
     @staticmethod
     def get_urls_from_definition(definition: OvalDefinition) -> Set[str]:

--- a/vulnerabilities/oval_parser.py
+++ b/vulnerabilities/oval_parser.py
@@ -35,7 +35,6 @@ from vulnerabilities.lib_oval import OvalDocument
 from vulnerabilities.lib_oval import OvalObject
 from vulnerabilities.lib_oval import OvalState
 from vulnerabilities.lib_oval import OvalTest
-import traceback
 
 
 class OvalParser:

--- a/vulnerabilities/oval_parser.py
+++ b/vulnerabilities/oval_parser.py
@@ -30,8 +30,12 @@ import xml.etree.ElementTree as ET
 
 from dephell_specifier import RangeSpecifier
 
-from vulnerabilities.lib_oval import (
-    OvalDefinition, OvalDocument, OvalTest, OvalObject, OvalState)
+from vulnerabilities.lib_oval import OvalDefinition
+from vulnerabilities.lib_oval import OvalDocument
+from vulnerabilities.lib_oval import OvalObject
+from vulnerabilities.lib_oval import OvalState
+from vulnerabilities.lib_oval import OvalTest
+import traceback
 
 
 class OvalParser:
@@ -45,8 +49,7 @@ class OvalParser:
 
     def get_data(self) -> List[Dict]:
         """
-        This is the orchestration method, it returns a list of dictionaries,
-        where each dictionary represents data from an OvalDefinition
+        Return a list of OvalDefinition mappings.
         """
         oval_data = []
         for definition in self.all_definitions:
@@ -55,27 +58,22 @@ class OvalParser:
             if not matching_tests:
                 continue
             definition_data = {'test_data': []}
-            definition_data['description'] = definition.getMetadata(
-            ).getDescription()  # this could use some data cleaning
+            # TODO:this could use some data cleaning
+            definition_data['description'] = definition.getMetadata().getDescription() or ''
 
-            if not definition_data['description']:
-                definition_data['description'] = ''
+            definition_data['vuln_id'] = self.get_vuln_id_from_definition(definition)
+            definition_data['reference_urls'] = self.get_urls_from_definition(definition)
 
-            definition_data['vuln_id'] = self.get_vuln_id_from_definition(
-                definition)
-            definition_data['reference_urls'] = self.get_urls_from_definition(
-                definition
-            )
             for test in matching_tests:
                 test_obj, test_state = self.get_object_state_of_test(test)
                 if not test_obj or not test_state:
                     continue
                 test_data = {'package_list': []}
-                test_data['package_list'].extend(
-                    self.get_pkgs_from_obj(test_obj))
-                test_data['version_ranges'] = self.get_versionsrngs_from_state(
-                    test_state)
+                test_data['package_list'].extend(self.get_pkgs_from_obj(test_obj))
+                version_ranges = self.get_versionsrngs_from_state(test_state)
+                test_data['version_ranges'] = version_ranges
                 definition_data['test_data'].append(test_data)
+
             oval_data.append(definition_data)
 
         return oval_data
@@ -138,18 +136,27 @@ class OvalParser:
 
         return pkg_list
 
+    # TODO: this method needs a better name
     def get_versionsrngs_from_state(self, state: OvalState) -> Optional[RangeSpecifier]:
         """
-        returns  all related version ranges within a state
+        Return a version range(s)? from a state
         """
         for var in state.element:
-            if var.get('operation'):
-                if var.get('operation') not in self.translations:
-                    continue
-                operand = self.translations[var.get('operation')]
-                version = var.text
-                version_range = operand + version
+            operation = var.get('operation')
+            if not operation:
+                continue
+            operand = self.translations.get(operation) or ''
+            if not operand:
+                continue
+            version = var.text or ''
+            if not version:
+                continue
+            version_range = operand + version
+            try:
                 return RangeSpecifier(version_range)
+            except Exception:
+                # FIXME: we should not continue
+                print(f"Failed to process invalid version_range in OvalState: {version_range}...continuing")  # nopep8
 
     @staticmethod
     def get_urls_from_definition(definition: OvalDefinition) -> Set[str]:

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -67,7 +67,7 @@ class LaunchpadVersionAPI(VersionAPI):
                     self.cache[pkg] = {}
                     break
                 for release in resp_json["entries"]:
-                    all_versions.add(release["source_package_version"])
+                    all_versions.add(release["source_package_version"].replace("0:", ""))
                 if resp_json.get("next_collection_link"):
                     url = resp_json["next_collection_link"]
                 else:
@@ -197,7 +197,7 @@ class DebianVersionAPI(VersionAPI):
                 self.cache[pkg] = {}
                 return
             for release in resp_json["versions"]:
-                all_versions.add(release["version"])
+                all_versions.add(release["version"].replace("0:", ""))
 
             self.cache[pkg] = all_versions
         # TODO : Handle ServerDisconnectedError by using some sort of

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -73,7 +73,7 @@ class LaunchpadVersionAPI(VersionAPI):
                 else:
                     break
             self.cache[pkg] = all_versions
-        except (ClientResponseError, asyncio.exceptions.TimeoutError):
+        except (ClientResponseError, asyncio.exceptions.TimeoutError, ServerDisconnectedError):
             self.cache[pkg] = {}
 
 

--- a/vulnerabilities/tests/test_basics.py
+++ b/vulnerabilities/tests/test_basics.py
@@ -26,20 +26,21 @@ import subprocess
 import sys
 import unittest
 
-
 root_dir = dirname(dirname(dirname(__file__)))
 bin_dir = dirname(sys.executable)
 
 
 class BaseTests(unittest.TestCase):
     def test_codestyle(self):
-        subprocess.check_output(
-            (
-                join(bin_dir, "pycodestyle")
-                + " --exclude=migrations,settings.py,venv,lib_oval.py,test_ubuntu.py,"
-                "test_suse.py,test_data_source.py "
-                "--max-line-length=100 "
-                "vulnerablecode vulnerabilities"
-            ).split(),
-            cwd=root_dir,
+        args = (
+            join(bin_dir, "pycodestyle") +
+            " --exclude=migrations,settings.py,venv,lib_oval.py,test_ubuntu.py,"
+            "test_suse.py,test_data_source.py "
+            "--max-line-length=100 "
+            "vulnerablecode vulnerabilities"
         )
+        try:
+                    
+            subprocess.check_output(args.split(), cwd=root_dir)
+        except Exception as e:
+            raise Exception(f'failed to run:\n{args}') from e

--- a/vulnerabilities/tests/test_basics.py
+++ b/vulnerabilities/tests/test_basics.py
@@ -38,7 +38,7 @@ class BaseTests(unittest.TestCase):
             "test_suse.py,test_data_source.py "
             "--max-line-length=100 "
             # Skip default and E252, triggered when using black-like style
-            "--ignore=E121,E123,E126,E226,E24,E704,W503,W504,E252"
+            "--ignore=E121,E123,E126,E226,E24,E704,W503,W504,E252 "
             "vulnerablecode vulnerabilities"
         )
         try:

--- a/vulnerabilities/tests/test_basics.py
+++ b/vulnerabilities/tests/test_basics.py
@@ -37,10 +37,11 @@ class BaseTests(unittest.TestCase):
             " --exclude=migrations,settings.py,venv,lib_oval.py,test_ubuntu.py,"
             "test_suse.py,test_data_source.py "
             "--max-line-length=100 "
+            # Skip default and E252, triggered when using black-like style
+            "--ignore=E121,E123,E126,E226,E24,E704,W503,W504,E252"
             "vulnerablecode vulnerabilities"
         )
         try:
-                    
             subprocess.check_output(args.split(), cwd=root_dir)
         except Exception as e:
             raise Exception(f'failed to run:\n{args}') from e

--- a/vulnerabilities/tests/test_debian_oval.py
+++ b/vulnerabilities/tests/test_debian_oval.py
@@ -33,10 +33,12 @@ class TestDebianOvalDataSource(unittest.TestCase):
         cls.debian_oval_data_src = DebianOvalDataSource(batch_size=1, config=data_source_cfg)
 
     @patch(
-        "vulnerabilities.importers.debian_oval.DebianVersionAPI.get",
-        return_value={"0:1.11.1+dfsg-5+deb7u1", "0:0.11.1+dfsg-5+deb7u1", "2.3.9"},
-    )
-    @patch("vulnerabilities.importers.debian_oval.DebianVersionAPI.load_api", new=mock)
+        'vulnerabilities.importers.debian_oval.DebianVersionAPI.get',
+        return_value={
+            '1.11.1+dfsg-5+deb7u1',
+            '0.11.1+dfsg-5+deb7u1',
+            '2.3.9'})
+    @patch('vulnerabilities.importers.debian_oval.DebianVersionAPI.load_api', new=mock)
     def test_get_data_from_xml_doc(self, mock_write):
         expected_advisories = [
             Advisory(
@@ -45,21 +47,36 @@ class TestDebianOvalDataSource(unittest.TestCase):
                     PackageURL(
                         type="deb",
                         namespace=None,
+<<<<<<< HEAD
                         name="krb5",
                         version="0:0.11.1+dfsg-5+deb7u1",
                         qualifiers=OrderedDict([("distro", "wheezy")]),
                         subpath=None,
                     )
                 },
+=======
+                        name='krb5',
+                        version='0.11.1+dfsg-5+deb7u1',
+                        qualifiers=OrderedDict([('distro', 'wheezy')]),
+                        subpath=None
+                    )},
+>>>>>>> Refactor to  handle default epochs
                 resolved_package_urls={
                     PackageURL(
                         type="deb",
                         namespace=None,
+<<<<<<< HEAD
                         name="krb5",
                         version="0:1.11.1+dfsg-5+deb7u1",
                         qualifiers=OrderedDict([("distro", "wheezy")]),
                         subpath=None,
                     ),
+=======
+                        name='krb5',
+                        version='1.11.1+dfsg-5+deb7u1',
+                        qualifiers=OrderedDict([('distro', 'wheezy')]),
+                        subpath=None),
+>>>>>>> Refactor to  handle default epochs
                     PackageURL(
                         type="deb",
                         namespace=None,
@@ -77,6 +94,7 @@ class TestDebianOvalDataSource(unittest.TestCase):
                     PackageURL(
                         type="deb",
                         namespace=None,
+<<<<<<< HEAD
                         name="a2ps",
                         version="0:0.11.1+dfsg-5+deb7u1",
                         qualifiers=OrderedDict([("distro", "wheezy")]),
@@ -104,6 +122,29 @@ class TestDebianOvalDataSource(unittest.TestCase):
                 vulnerability_id="CVE-2001-1593",
             ),
         ]
+=======
+                        name='a2ps',
+                        version='0.11.1+dfsg-5+deb7u1',
+                        qualifiers=OrderedDict([('distro', 'wheezy')]),
+                        subpath=None
+                    )},
+                resolved_package_urls={
+                    PackageURL(type='deb',
+                               namespace=None,
+                               name='a2ps',
+                               version='2.3.9',
+                               qualifiers=OrderedDict([('distro', 'wheezy')]),
+                               subpath=None),
+                    PackageURL(type='deb',
+                               namespace=None,
+                               name='a2ps',
+                               version='1.11.1+dfsg-5+deb7u1',
+                               qualifiers=OrderedDict([('distro', 'wheezy')]),
+                               subpath=None)},
+                vulnerability_id='CVE-2001-1593')
+
+        }
+>>>>>>> Refactor to  handle default epochs
 
         xml_doc = ET.parse(os.path.join(TEST_DATA, "debian_oval_data.xml"))
         # Dirty quick patch to mock batch_advisories

--- a/vulnerabilities/tests/test_debian_oval.py
+++ b/vulnerabilities/tests/test_debian_oval.py
@@ -47,36 +47,19 @@ class TestDebianOvalDataSource(unittest.TestCase):
                     PackageURL(
                         type="deb",
                         namespace=None,
-<<<<<<< HEAD
-                        name="krb5",
-                        version="0:0.11.1+dfsg-5+deb7u1",
-                        qualifiers=OrderedDict([("distro", "wheezy")]),
-                        subpath=None,
-                    )
-                },
-=======
                         name='krb5',
                         version='0.11.1+dfsg-5+deb7u1',
                         qualifiers=OrderedDict([('distro', 'wheezy')]),
                         subpath=None
                     )},
->>>>>>> Refactor to  handle default epochs
                 resolved_package_urls={
                     PackageURL(
                         type="deb",
                         namespace=None,
-<<<<<<< HEAD
-                        name="krb5",
-                        version="0:1.11.1+dfsg-5+deb7u1",
-                        qualifiers=OrderedDict([("distro", "wheezy")]),
-                        subpath=None,
-                    ),
-=======
                         name='krb5',
                         version='1.11.1+dfsg-5+deb7u1',
                         qualifiers=OrderedDict([('distro', 'wheezy')]),
                         subpath=None),
->>>>>>> Refactor to  handle default epochs
                     PackageURL(
                         type="deb",
                         namespace=None,
@@ -94,35 +77,6 @@ class TestDebianOvalDataSource(unittest.TestCase):
                     PackageURL(
                         type="deb",
                         namespace=None,
-<<<<<<< HEAD
-                        name="a2ps",
-                        version="0:0.11.1+dfsg-5+deb7u1",
-                        qualifiers=OrderedDict([("distro", "wheezy")]),
-                        subpath=None,
-                    )
-                },
-                resolved_package_urls={
-                    PackageURL(
-                        type="deb",
-                        namespace=None,
-                        name="a2ps",
-                        version="2.3.9",
-                        qualifiers=OrderedDict([("distro", "wheezy")]),
-                        subpath=None,
-                    ),
-                    PackageURL(
-                        type="deb",
-                        namespace=None,
-                        name="a2ps",
-                        version="0:1.11.1+dfsg-5+deb7u1",
-                        qualifiers=OrderedDict([("distro", "wheezy")]),
-                        subpath=None,
-                    ),
-                },
-                vulnerability_id="CVE-2001-1593",
-            ),
-        ]
-=======
                         name='a2ps',
                         version='0.11.1+dfsg-5+deb7u1',
                         qualifiers=OrderedDict([('distro', 'wheezy')]),
@@ -144,7 +98,6 @@ class TestDebianOvalDataSource(unittest.TestCase):
                 vulnerability_id='CVE-2001-1593')
 
         }
->>>>>>> Refactor to  handle default epochs
 
         xml_doc = ET.parse(os.path.join(TEST_DATA, "debian_oval_data.xml"))
         # Dirty quick patch to mock batch_advisories

--- a/vulnerabilities/tests/test_debian_oval.py
+++ b/vulnerabilities/tests/test_debian_oval.py
@@ -97,7 +97,7 @@ class TestDebianOvalDataSource(unittest.TestCase):
                                subpath=None)},
                 vulnerability_id='CVE-2001-1593')
 
-        }
+        ]
 
         xml_doc = ET.parse(os.path.join(TEST_DATA, "debian_oval_data.xml"))
         # Dirty quick patch to mock batch_advisories

--- a/vulnerabilities/tests/test_suse.py
+++ b/vulnerabilities/tests/test_suse.py
@@ -103,7 +103,7 @@ class TestSUSEOvalParser(unittest.TestCase):
         state_2 = self.parsed_oval.oval_document.getStates()[1]
 
         exp_range_1 = None
-        exp_range_2 = RangeSpecifier("<0:1.2.11-lp151.3.6")
+        exp_range_2 = RangeSpecifier("<1.2.11-lp151.3.6")
         #In a full run we wont get exp_range1 because we won't obtain 
         #it's state due to filters to  avoid such tests in  the first place
         assert self.parsed_oval.get_version_ranges_from_state(state_1) == exp_range_1
@@ -131,36 +131,36 @@ class TestSUSEOvalParser(unittest.TestCase):
     def test_get_data(self):
 
         expected_data = [
-            {
-                "test_data": [
-                    {
-                        "package_list": ["cacti"],
-                        "version_ranges": RangeSpecifier("<0:1.2.11-lp151.3.6"),
-                    },
-                    {
-                        "package_list": ["cacti-spine"],
-                        "version_ranges": RangeSpecifier("<0:1.2.11-lp151.3.6"),
-                    },
-                ],
-                "description": '\n        Cacti 0.8.7e and earlier allows remote authenticated administrators to gain privileges by modifying the "Data Input Method" for the "Linux - Get Memory Usage" setting to contain arbitrary commands.\n        ',
-                "vuln_id": "CVE-2009-4112",
-                "reference_urls": {
-                    "https://bugzilla.suse.com/1122535",
-                    "https://bugzilla.suse.com/558664",
-                    "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-4112",
-                    "https://www.suse.com/security/cve/CVE-2009-4112.html",
+          {
+            'test_data':
+            [
+                {
+                'package_list': ['cacti'],
+                'version_ranges': RangeSpecifier("<1.2.11-lp151.3.6")
+                }
+                ,
+                {
+                'package_list': ['cacti-spine'],
+                'version_ranges': RangeSpecifier("<1.2.11-lp151.3.6")
+                }
+           ],
+        'description':'\n        Cacti 0.8.7e and earlier allows remote authenticated administrators to gain privileges by modifying the "Data Input Method" for the "Linux - Get Memory Usage" setting to contain arbitrary commands.\n        ',
+        'vuln_id': 'CVE-2009-4112',
+        'reference_urls': {
+            'https://bugzilla.suse.com/1122535',
+            'https://bugzilla.suse.com/558664',
+            'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-4112',
+            'https://www.suse.com/security/cve/CVE-2009-4112.html'}
+        },
+          { 'test_data':
+            [
+                {
+                'package_list': ['apache2-mod_perl'],
+                'version_ranges': RangeSpecifier("<2.0.11-lp151.3.3")
                 },
-            },
-            {
-                "test_data": [
-                    {
-                        "package_list": ["apache2-mod_perl"],
-                        "version_ranges": RangeSpecifier("<0:2.0.11-lp151.3.3"),
-                    },
-                    {
-                        "package_list": ["apache2-mod_perl-devel"],
-                        "version_ranges": RangeSpecifier("<0:2.0.11-lp151.3.3"),
-                    },
+                {
+                'package_list': ['apache2-mod_perl-devel'],
+                'version_ranges': RangeSpecifier("<2.0.11-lp151.3.3")}
                 ],
                 "description": "\n        mod_perl 2.0 through 2.0.10 allows attackers to execute arbitrary Perl code by placing it in a user-owned .htaccess file, because (contrary to the documentation) there is no configuration option that permits Perl code for the administrator's control of HTTP request processing without also permitting unprivileged users to run Perl code in the context of the user account that runs Apache HTTP Server processes.\n        ",
                 "vuln_id": "CVE-2011-2767",

--- a/vulnerabilities/tests/test_suse.py
+++ b/vulnerabilities/tests/test_suse.py
@@ -95,7 +95,7 @@ class TestSUSEOvalParser(unittest.TestCase):
         # it's object due to filters to  avoid such tests in  the first place
         assert pkg_set2 == {"cacti"}
 
-    def test_get_versionsrngs_from_state(self):
+    def test_get_version_ranges_from_state(self):
 
         assert len(self.parsed_oval.oval_document.getStates()) == 4
 
@@ -104,11 +104,11 @@ class TestSUSEOvalParser(unittest.TestCase):
 
         exp_range_1 = None
         exp_range_2 = RangeSpecifier("<0:1.2.11-lp151.3.6")
-        # In a full run we wont get exp_range1 because we won't obtain
-        # it's state due to filters to  avoid such tests in  the first place
-        assert self.parsed_oval.get_versionsrngs_from_state(state_1) == exp_range_1
-        assert self.parsed_oval.get_versionsrngs_from_state(state_2) == exp_range_2
-
+        #In a full run we wont get exp_range1 because we won't obtain 
+        #it's state due to filters to  avoid such tests in  the first place
+        assert self.parsed_oval.get_version_ranges_from_state(state_1) == exp_range_1
+        assert self.parsed_oval.get_version_ranges_from_state(state_2) == exp_range_2
+    
     def test_get_urls_from_definition(self):
 
         def1_urls = {

--- a/vulnerabilities/tests/test_ubuntu.py
+++ b/vulnerabilities/tests/test_ubuntu.py
@@ -90,7 +90,7 @@ class TestUbuntuOvalParser(unittest.TestCase):
         assert pkg_set1 == {"potrace"}
         assert pkg_set2 == {"tor"}
 
-    def test_get_versionsrngs_from_state(self):
+    def test_get_version_ranges_from_state(self):
 
         assert len(self.parsed_oval.oval_document.getStates()) == 2
 
@@ -100,8 +100,8 @@ class TestUbuntuOvalParser(unittest.TestCase):
         exp_range_1 = RangeSpecifier("<1.14-2")
         exp_range_2 = RangeSpecifier("<0.2.8.9-1ubuntu1")
 
-        assert self.parsed_oval.get_versionsrngs_from_state(state_1) == exp_range_1
-        assert self.parsed_oval.get_versionsrngs_from_state(state_2) == exp_range_2
+        assert self.parsed_oval.get_version_ranges_from_state(state_1) == exp_range_1
+        assert self.parsed_oval.get_version_ranges_from_state(state_2) == exp_range_2
 
     def test_get_urls_from_definition(self):
 


### PR DESCRIPTION
There are a few issues with the Ubuntu Oval importer that was stuck.
This resolves some of these issues:
- Do not fail when there is a version range that cannot be parsed as a RangeSpecifier(). 
- Improve error handling
- Add simple logging using print statements to help monitor import progress
- Also apply minor code formatting.
- I also added a code comment about the Etag handling which IMHO are more problematic than helpful at this stage, especially when there is a failure during import. See also #321

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>