### PR TITLE
Update pypi deps db to 2021-03-06.

### DIFF
--- a/etc/nix/flake.lock
+++ b/etc/nix/flake.lock
@@ -22,16 +22,16 @@
         "pypi-deps-db": "pypi-deps-db"
       },
       "locked": {
-        "lastModified": 1606460537,
-        "narHash": "sha256-gcKjBA1fpCzh0nGoaxurIjIJanPDrAea6NK60M+vfRk=",
+        "lastModified": 1614316305,
+        "narHash": "sha256-GLZqAazQu7zYR/1VU8QpjdrPdNMn9H8QdlMukT1TeZQ=",
         "owner": "DavHau",
         "repo": "mach-nix",
-        "rev": "1ec92303acd142aa1a3b60bb97745544cf049312",
+        "rev": "235a0a81d05a043bca2a93442f2560946266fc73",
         "type": "github"
       },
       "original": {
         "owner": "DavHau",
-        "ref": "3.1.1",
+        "ref": "235a0a81d05a043bca2a93442f2560946266fc73",
         "repo": "mach-nix",
         "type": "github"
       }

--- a/etc/nix/flake.nix
+++ b/etc/nix/flake.nix
@@ -13,7 +13,7 @@
     type = "github";
     owner = "DavHau";
     repo = "mach-nix";
-    ref = "3.1.1";
+    ref = "235a0a81d05a043bca2a93442f2560946266fc73";
   };
 
   outputs = { self, nixpkgs, machnix }:

--- a/etc/nix/flake.nix
+++ b/etc/nix/flake.nix
@@ -53,9 +53,9 @@
           # mach-nix release) is usually insufficient. Use
           # ./get-latest-pypi-deps-db.sh to obtain the data rev & hash.
           pypiDataRev =
-            "894c2005d655011934c04d150f8c57d25a25e29d"; # 2021-03-04T20:10:42Z
+            "499750266bb4b2840cbe856c2cc0e3297685e362"; # 2021-03-06T08:13:08Z
           pypiDataSha256 =
-            "1y6297drhbv34da1rjwp01s8wwwqkwxjsq3rkjcdqy69w4r987rz";
+            "188g24k8pk4lgqybywimkvwjwh8014v6l2mrkvzv309882i9p5gc";
         });
 
     in {


### PR DESCRIPTION
Simple update of the pypi index.
With a working [Nix]() setup, all you have to do is running ``./etc/nix/get-latest-pypi-deps-db.sh`` and use its output to update ``/etc/nix/flake.nix``