### PR TITLE
Explicity provide lxml parser to beautifulsoup 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           pip install -r requirements.txt
     
       - name: Run tests
-        run: pytest
+        run: python -m pytest
         env:
           # The hostname, username used to communicate with the PostgreSQL service container
           POSTGRES_HOST: localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 script:
   - ./manage.py collectstatic
-  - pytest
+  - python -m pytest
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -245,7 +245,7 @@ Start the webserver::
 
 For full documentation about API endpoints use this URL::
 
-    http://127.0.0.1:8000/api/schema/swagger-ui/
+    http://127.0.0.1:8000/api/docs
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ Run Tests
 Use these commands to run code style checks and the test suite::
 
     black -l 100 --check .
-    DJANGO_DEV=1 pytest
+    DJANGO_DEV=1 python -m pytest
 
 
 Data import
@@ -245,7 +245,7 @@ Start the webserver::
 
 For full documentation about API endpoints use this URL::
 
-    http://127.0.0.1:8000/api/docs
+    http://127.0.0.1:8000/api/schema/swagger-ui/
 
 
 

--- a/vulnerabilities/importers/nginx.py
+++ b/vulnerabilities/importers/nginx.py
@@ -66,7 +66,7 @@ class NginxDataSource(DataSource):
 
     def to_advisories(self, data):
         advisories = []
-        soup = BeautifulSoup(data)
+        soup = BeautifulSoup(data, features="lxml")
         vuln_list = soup.select("li p")
 
         # Example value of `vuln_list` :

--- a/vulnerabilities/importers/postgresql.py
+++ b/vulnerabilities/importers/postgresql.py
@@ -58,7 +58,7 @@ class PostgreSQLDataSource(DataSource):
 
 def to_advisories(data):
     advisories = []
-    soup = BeautifulSoup(data)
+    soup = BeautifulSoup(data, features="lxml")
     table = soup.select("table")[0]
     for row in table.select("tbody tr"):
         ref_col, affected_col, fixed_col, severity_score_col, desc_col = row.select("td")

--- a/vulnerablecode/urls.py
+++ b/vulnerablecode/urls.py
@@ -88,7 +88,7 @@ curation_views = [
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(), name="swagger-ui"),
+    path("api/docs", SpectacularSwaggerView.as_view(), name="swagger-ui"),
     path("packages/search", PackageSearchView.as_view(), name="package_search"),
     path("packages/<int:pk>", PackageUpdate.as_view(), name="package_view"),
     path("vulnerabilities/<int:pk>", VulnerabilityDetails.as_view(), name="vulnerability_view"),


### PR DESCRIPTION
BeautifulSoup would generate warnings without an explicit parser.
It is always better to look at clean test results than one filled with
warnings.