### PR TITLE
Explicity provide lxml parser to beautifulsoup

### DIFF
--- a/vulnerabilities/importers/nginx.py
+++ b/vulnerabilities/importers/nginx.py
@@ -66,7 +66,7 @@ class NginxDataSource(DataSource):
 
     def to_advisories(self, data):
         advisories = []
-        soup = BeautifulSoup(data)
+        soup = BeautifulSoup(data, features="lxml")
         vuln_list = soup.select("li p")
 
         # Example value of `vuln_list` :

--- a/vulnerabilities/importers/postgresql.py
+++ b/vulnerabilities/importers/postgresql.py
@@ -58,7 +58,7 @@ class PostgreSQLDataSource(DataSource):
 
 def to_advisories(data):
     advisories = []
-    soup = BeautifulSoup(data)
+    soup = BeautifulSoup(data, features="lxml")
     table = soup.select("table")[0]
     for row in table.select("tbody tr"):
         ref_col, affected_col, fixed_col, severity_score_col, desc_col = row.select("td")


### PR DESCRIPTION
BeautifulSoup would generate warnings without an explicit parser which
shows up in the test results as well.
It is always better to look at clean test results than one filled with
unnecessary warnings.