### PR TITLE
enable configuration of allowed host

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,11 @@ for this purpose::
 
     SECRET_KEY=$(python -c "from django.core.management import utils; print(utils.get_random_secret_key())")
 
+You will also need to setup the VC_ALLOWED_HOSTS environment variable to match the hostname where the app is deployed::
+
+    VC_ALLOWED_HOSTS=vulnerablecode.your.domain.example.com
+
+You can specify several host by separating them with a colon `:`
 
 Using Nix
 ~~~~~~~~~

--- a/vulnerablecode/settings.py
+++ b/vulnerablecode/settings.py
@@ -27,9 +27,7 @@ if not DEV_MODE:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = [
-    ".herokuapp.com",
-]
+ALLOWED_HOSTS = os.environ.get("VC_ALLOWED_HOSTS", "*").split(":")
 
 # Application definition
 


### PR DESCRIPTION
when deploying this outside of heroku, we get strange 400 errors, which turn out to be this variable that needs to be configured.
