### PR TITLE
Backend: Fix duplicate reference urls(#343)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,4 @@ requests==2.23.0
 toml==0.10.2
 PyYAML==5.4
 freezegun==1.1.0
+urlpy==0.5

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -112,7 +112,7 @@ class VulnerabilityReference(models.Model):
         return VulnerabilitySeverity.objects.filter(reference=self.id)
 
     def save(self, *args, **kwargs):
-        if self.id:
+        if self.id or not self.url:
             super(VulnerabilityReference, self).save(*args, **kwargs)
         else:
             url_parsed = urlpy.parse(self.url)


### PR DESCRIPTION
Fix: #343.

The following changes are been proposed in this PR:
- [x] Saving URLs in canonical form ('http://foo.com/?b=2&a=1&d=3' -> 'http://foo.com/?a=1&b=2&d=3'
- [x] If provided url is http but we already have the url with https we ignore the http url.
- [x] If provided url is https but we already have the url with http we replace the http url with https one 