### PR TITLE
Add unspecified scoring system

### DIFF
--- a/vulnerabilities/severity_systems.py
+++ b/vulnerabilities/severity_systems.py
@@ -81,4 +81,10 @@ scoring_systems = {
         url="https://www.first.org/cvss/specification-document#Qualitative-Severity-Rating-Scale",
         notes="A textual interpretation of severity. Has values like HIGH, MODERATE etc",
     ),
+    "unspecified": ScoringSystem(
+        identifier="unspecified",
+        name="unspecified",
+        url="https://example.com",
+        notes="Severity with unspecified scoring system. Contains values like High, Low etc",
+    ),
 }

--- a/vulnerabilities/severity_systems.py
+++ b/vulnerabilities/severity_systems.py
@@ -81,10 +81,10 @@ scoring_systems = {
         url="https://www.first.org/cvss/specification-document#Qualitative-Severity-Rating-Scale",
         notes="A textual interpretation of severity. Has values like HIGH, MODERATE etc",
     ),
-    "unspecified": ScoringSystem(
-        identifier="unspecified",
-        name="unspecified",
-        url="https://example.com",
-        notes="Severity with unspecified scoring system. Contains values like High, Low etc",
+    "generic_textual": ScoringSystem(
+        identifier="generic_textual",
+        name="Generic textual severity rating",
+        url="",
+        notes="Severity for unknown scoring systems. Contains generic textual values like High, Low etc",
     ),
 }


### PR DESCRIPTION
This could be used where the scale of scoring system is unspecified and do not correspond to a numeric representation. This must be used as the last resort. 
Required in https://github.com/nexB/vulnerablecode/pull/397#discussion_r603774595 and https://github.com/nexB/vulnerablecode/pull/393#discussion_r603964317

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>