### PR TITLE
Fix redhat import failure

### DIFF
--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -25,6 +25,7 @@ import re
 
 import requests
 import toml
+import urllib3
 import yaml
 
 # TODO add logging here
@@ -79,3 +80,21 @@ def create_etag(data_src, url, etag_key):
 
 
 is_cve = re.compile(r"CVE-\d+-\d+", re.IGNORECASE).match
+
+
+def requests_with_5xx_retry(max_retries=5, backoff_factor=0.5):
+    """
+    Returns a requests sessions which retries on 5xx errors with
+    a backoff_factor
+    """
+    retries = urllib3.util.Retry(
+        total=max_retries,
+        backoff_factor=backoff_factor,
+        raise_on_status=True,
+        status_forcelist=range(500, 600, 1),
+    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=retries)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/vulnerabilities/importers/redhat.py
+++ b/vulnerabilities/importers/redhat.py
@@ -20,16 +20,19 @@
 #  VulnerableCode is a free software code from nexB Inc. and others.
 #  Visit https://github.com/nexB/vulnerablecode/ for support and download.
 
-from packageurl import PackageURL
 import requests
+from packageurl import PackageURL
 
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import DataSource
 from vulnerabilities.data_source import DataSourceConfiguration
 from vulnerabilities.data_source import Reference
 from vulnerabilities.data_source import VulnerabilitySeverity
+from vulnerabilities.helpers import requests_with_5xx_retry
 from vulnerabilities.severity_systems import scoring_systems
 
+
+import pdb
 
 class RedhatDataSource(DataSource):
     CONFIG_CLASS = DataSourceConfiguration
@@ -41,6 +44,9 @@ class RedhatDataSource(DataSource):
     def updated_advisories(self):
         processed_advisories = list(map(to_advisory, self.redhat_cves))
         return self.batch_advisories(processed_advisories)
+
+
+requests_session = requests_with_5xx_retry(max_retries=5, backoff_factor=1)
 
 
 def fetch():
@@ -58,7 +64,7 @@ def fetch():
         current_url = url_template.format(page_no)
         try:
             print(f"Fetching: {current_url}")
-            response = requests.get(current_url)
+            response = requests_session.get(current_url)
             if response.status_code != requests.codes.ok:
                 # TODO: log me
                 print(f"Failed to fetch results from {current_url}")
@@ -79,88 +85,98 @@ def fetch():
 
 
 def to_advisory(advisory_data):
-    affected_purls = []
-    if advisory_data.get("affected_packages"):
-        for rpm in advisory_data["affected_packages"]:
-            purl = rpm_to_purl(rpm)
-            if purl:
-                affected_purls.append(purl)
+    try:
+        affected_purls = []
+        if advisory_data.get("affected_packages"):
+            for rpm in advisory_data["affected_packages"]:
+                purl = rpm_to_purl(rpm)
+                if purl:
+                    affected_purls.append(purl)
 
-    references = []
-    bugzilla = advisory_data.get("bugzilla")
-    if bugzilla:
-        url = "https://bugzilla.redhat.com/show_bug.cgi?id={}".format(bugzilla)
-        bugzilla_data = requests.get(f"https://bugzilla.redhat.com/rest/bug/{bugzilla}").json()
-        if (
-            bugzilla_data.get("bugs")
-            and len(bugzilla_data["bugs"])
-            and bugzilla_data["bugs"][0].get("severity")
-        ):
-            bugzilla_severity_val = bugzilla_data["bugs"][0]["severity"]
-            bugzilla_severity = VulnerabilitySeverity(
-                system=scoring_systems["rhbs"],
-                value=bugzilla_severity_val,
-            )
+        references = []
+        bugzilla = advisory_data.get("bugzilla")
+        if bugzilla:
+            url = "https://bugzilla.redhat.com/show_bug.cgi?id={}".format(bugzilla)
+            bugzilla_data = requests_session.get(
+                f"https://bugzilla.redhat.com/rest/bug/{bugzilla}"
+            ).json()
+            if (
+                bugzilla_data.get("bugs")
+                and len(bugzilla_data["bugs"])
+                and bugzilla_data["bugs"][0].get("severity")
+            ):
+                bugzilla_severity_val = bugzilla_data["bugs"][0]["severity"]
+                bugzilla_severity = VulnerabilitySeverity(
+                    system=scoring_systems["rhbs"],
+                    value=bugzilla_severity_val,
+                )
 
-            references.append(
-                Reference(
-                    severities=[bugzilla_severity],
-                    url=url,
-                    reference_id=bugzilla,
+                references.append(
+                    Reference(
+                        severities=[bugzilla_severity],
+                        url=url,
+                        reference_id=bugzilla,
+                    )
+                )
+
+        for rh_adv in advisory_data["advisories"]:
+            # RH provides 3 types of advisories RHSA, RHBA, RHEA. Only RHSA's contain severity score.
+            # See https://access.redhat.com/articles/2130961 for more details.
+
+            if "RHSA" in rh_adv.upper():
+                rhsa_data = requests_session.get(
+                    f"https://access.redhat.com/hydra/rest/securitydata/cvrf/{rh_adv}.json"
+                ).json()  # nopep8
+                value = rhsa_data["cvrfdoc"]["aggregate_severity"]
+                rhsa_aggregate_severity = VulnerabilitySeverity(
+                    system=scoring_systems["rhas"],
+                    value=value,
+                )
+
+                references.append(
+                    Reference(
+                        severities=[rhsa_aggregate_severity],
+                        url="https://access.redhat.com/errata/{}".format(rh_adv),
+                        reference_id=rh_adv,
+                    )
+                )
+
+            else:
+                references.append(
+                    Reference(severities=[], url=url, reference_id=rh_adv)
+                )
+
+        redhat_scores = []
+        cvssv3_score = advisory_data.get("cvss3_score")
+        if cvssv3_score:
+            redhat_scores.append(
+                VulnerabilitySeverity(
+                    system=scoring_systems["cvssv3"],
+                    value=cvssv3_score,
                 )
             )
 
-    for rh_adv in advisory_data["advisories"]:
-        # RH provides 3 types of advisories RHSA, RHBA, RHEA. Only RHSA's contain severity score.
-        # See https://access.redhat.com/articles/2130961 for more details.
-
-        if "RHSA" in rh_adv.upper():
-            rhsa_data = requests.get(
-                f"https://access.redhat.com/hydra/rest/securitydata/cvrf/{rh_adv}.json"
-            ).json()  # nopep8
-            value = rhsa_data["cvrfdoc"]["aggregate_severity"]
-            rhsa_aggregate_severity = VulnerabilitySeverity(
-                system=scoring_systems["rhas"],
-                value=value,
-            )
-
-            references.append(
-                Reference(
-                    severities=[rhsa_aggregate_severity],
-                    url="https://access.redhat.com/errata/{}".format(rh_adv),
-                    reference_id=rh_adv,
+        cvssv3_vector = advisory_data.get("cvss3_scoring_vector")
+        if cvssv3_vector:
+            redhat_scores.append(
+                VulnerabilitySeverity(
+                    system=scoring_systems["cvssv3_vector"],
+                    value=cvssv3_vector,
                 )
             )
 
-        else:
-            references.append(Reference(severities=[], url=url, reference_id=rh_adv))
-
-    redhat_scores = []
-    cvssv3_score = advisory_data.get("cvss3_score")
-    if cvssv3_score:
-        redhat_scores.append(
-            VulnerabilitySeverity(
-                system=scoring_systems["cvssv3"],
-                value=cvssv3_score,
-            )
+        references.append(
+            Reference(severities=redhat_scores, url=advisory_data["resource_url"])
         )
-
-    cvssv3_vector = advisory_data.get("cvss3_scoring_vector")
-    if cvssv3_vector:
-        redhat_scores.append(
-            VulnerabilitySeverity(
-                system=scoring_systems["cvssv3_vector"],
-                value=cvssv3_vector,
-            )
+        return Advisory(
+            vulnerability_id=advisory_data["CVE"],
+            summary=advisory_data["bugzilla_description"],
+            impacted_package_urls=affected_purls,
+            references=references,
         )
-
-    references.append(Reference(severities=redhat_scores, url=advisory_data["resource_url"]))
-    return Advisory(
-        vulnerability_id=advisory_data["CVE"],
-        summary=advisory_data["bugzilla_description"],
-        impacted_package_urls=affected_purls,
-        references=references,
-    )
+    except Exception as e:
+        print(e)
+        pdb.set_trace()
 
 
 def rpm_to_purl(rpm_string):

--- a/vulnerabilities/importers/redhat.py
+++ b/vulnerabilities/importers/redhat.py
@@ -127,15 +127,19 @@ def to_advisory(advisory_data):
                 rhsa_data = requests_session.get(
                     f"https://access.redhat.com/hydra/rest/securitydata/cvrf/{rh_adv}.json"
                 ).json()  # nopep8
-                value = rhsa_data["cvrfdoc"]["aggregate_severity"]
-                rhsa_aggregate_severity = VulnerabilitySeverity(
-                    system=scoring_systems["rhas"],
-                    value=value,
-                )
+
+                rhsa_aggregate_severities = []
+                if rhsa_data.get("cvrfdoc"):
+                    # not all RHSA errata have a corresponding CVRF document
+                    value = rhsa_data["cvrfdoc"]["aggregate_severity"]
+                    rhsa_aggregate_severities.append(VulnerabilitySeverity(
+                        system=scoring_systems["rhas"],
+                        value=value,
+                    ))
 
                 references.append(
                     Reference(
-                        severities=[rhsa_aggregate_severity],
+                        severities=rhsa_aggregate_severities,
                         url="https://access.redhat.com/errata/{}".format(rh_adv),
                         reference_id=rh_adv,
                     )

--- a/vulnerabilities/tests/test_redhat_importer.py
+++ b/vulnerabilities/tests/test_redhat_importer.py
@@ -139,7 +139,7 @@ class TestRedhat(unittest.TestCase):
         }
         for adv in data:
             with unittest.mock.patch(
-                "vulnerabilities.importers.redhat.requests.get", return_value=mock_resp
+                "vulnerabilities.importers.redhat.requests_session.get", return_value=mock_resp
             ):
                 adv = redhat.to_advisory(adv)
                 found_advisories.append(adv)


### PR DESCRIPTION
This fixes #398. 
This PR is mainly comprises of following two commits.

---
### requests_with_5xx_retry: Retry on 5xx errors

Introduced and used a helper function for retries on 5xx errors. This is
important and some servers like bugzilla.redhat.com return 502 Proxy Error
which was the cause of #398

A ticket has been raised in RedHat here https://redhat.service-now.com/help?id=rh_ticket&table=sc_req_item&sys_id=278239541b1ba010477e43fccd4bcb4a

Here is the response from bugzilla-owner@redhat.com
> Yes, just back off a bit and retry when this happens. It's been a long-term issue and we're working on a way to address it but it will still take time. There's also a time-out on individual queries - if you're hitting that sometimes on other requests then you'll need to optimise them or break them up into smaller ones
---
### Not all RHSA errata have a CVRF document

This is mentioned in the NOTE of "2.1 List all CVRFs" of
https://access.redhat.com/documentation/en-us/red_hat_security_data_api/1.0/html/red_hat_security_data_api/cvrf

Such a case would lead to a crash before this commit.
Eg: https://access.redhat.com/hydra/rest/securitydata/cvrf/RHSA-2005:835.json
No cvrfdoc would be found in the statement
                    value = rhsa_data["cvrfdoc"]["aggregate_severity"]

