### PR TITLE
helper: split_markdown_front_matter

### DIFF
--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -26,6 +26,7 @@ import json
 import re
 from typing import Optional
 from typing import List
+from typing import Tuple
 
 import requests
 import saneyaml
@@ -164,3 +165,30 @@ def nearest_patched_package(
         )
 
     return affected_package_with_patched_package_objects
+
+
+def split_markdown_front_matter(text: str) -> Tuple[str, str]:
+    r"""
+    Split text into markdown front matter and the markdown body
+    Returns ("", text) for text with non existing front matter
+
+    >>> text='''---
+    ... title: DUMMY-SECURITY-2019-001
+    ... description: Incorrect access control.
+    ... cves: [CVE-2042-1337]
+    ... ---
+    ... # Markdown starts here
+    ... '''
+    >>> split_markdown_front_matter(text)
+    ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]\n', '\n# Markdown starts here\n')
+    """
+
+    front_matter = ""
+    body = text
+    text = text.replace("\r\n", "\n")
+    linezero,_, text = text.partition("---\n")
+
+    if not linezero: # nothing before first ---
+        front_matter,_, body = text.partition("---")
+
+    return front_matter, body

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -167,7 +167,7 @@ def nearest_patched_package(
     return affected_package_with_patched_package_objects
 
 
-def split_markdown_front_matter(text: str) -> Tuple[str, str]:
+def split_markdown_front_matter(lines: str) -> Tuple[str, str]:
     r"""
     Split text into markdown front matter and the markdown body
     Return ("", text) for text with non existing front matter
@@ -180,15 +180,19 @@ def split_markdown_front_matter(text: str) -> Tuple[str, str]:
     ... # Markdown starts here
     ... '''
     >>> split_markdown_front_matter(text)
-    ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]\n', '\n# Markdown starts here\n')
+    ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]', '# Markdown starts here\n')
     """
+    fmlines = []
+    mdlines = []
+    splitter = mdlines
 
-    front_matter = ""
-    body = text
-    text = text.replace("\r\n", "\n")
-    linezero, _, text = text.partition("---\n")
+    lines = lines.replace("\r\n", "\n")
+    for index, line in enumerate(lines.split("\n")):
+        if index == 0 and line.strip().startswith("---"):
+            splitter = fmlines
+        elif line.strip().startswith("---"):
+            splitter = mdlines
+        else:
+            splitter.append(line)
 
-    if not linezero:  # nothing before first ---
-        front_matter, _, body = text.partition("---")
-
-    return front_matter, body
+    return "\n".join(fmlines), "\n".join(mdlines)

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -24,8 +24,8 @@ import bisect
 import dataclasses
 import json
 import re
-from typing import Optional
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import requests
@@ -182,6 +182,7 @@ def split_markdown_front_matter(text: str) -> Tuple[str, str]:
     >>> split_markdown_front_matter(text)
     ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]', '# Markdown starts here')
     """
+    # The doctest contains \n and for the sake of clarity I chose raw strings than escaping those.
     lines = text.splitlines()
     if lines[0] == "---":
         lines = lines[1:]

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -186,9 +186,9 @@ def split_markdown_front_matter(text: str) -> Tuple[str, str]:
     front_matter = ""
     body = text
     text = text.replace("\r\n", "\n")
-    linezero,_, text = text.partition("---\n")
+    linezero, _, text = text.partition("---\n")
 
-    if not linezero: # nothing before first ---
-        front_matter,_, body = text.partition("---")
+    if not linezero:  # nothing before first ---
+        front_matter, _, body = text.partition("---")
 
     return front_matter, body

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -170,7 +170,7 @@ def nearest_patched_package(
 def split_markdown_front_matter(text: str) -> Tuple[str, str]:
     r"""
     Split text into markdown front matter and the markdown body
-    Returns ("", text) for text with non existing front matter
+    Return ("", text) for text with non existing front matter
 
     >>> text='''---
     ... title: DUMMY-SECURITY-2019-001

--- a/vulnerabilities/helpers.py
+++ b/vulnerabilities/helpers.py
@@ -167,10 +167,10 @@ def nearest_patched_package(
     return affected_package_with_patched_package_objects
 
 
-def split_markdown_front_matter(lines: str) -> Tuple[str, str]:
+def split_markdown_front_matter(text: str) -> Tuple[str, str]:
     r"""
-    Split text into markdown front matter and the markdown body
-    Return ("", text) for text with non existing front matter
+    Return a tuple of (front matter, markdown body) strings split from ``text``.
+    Each can be an empty string.
 
     >>> text='''---
     ... title: DUMMY-SECURITY-2019-001
@@ -180,19 +180,13 @@ def split_markdown_front_matter(lines: str) -> Tuple[str, str]:
     ... # Markdown starts here
     ... '''
     >>> split_markdown_front_matter(text)
-    ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]', '# Markdown starts here\n')
+    ('title: DUMMY-SECURITY-2019-001\ndescription: Incorrect access control.\ncves: [CVE-2042-1337]', '# Markdown starts here')
     """
-    fmlines = []
-    mdlines = []
-    splitter = mdlines
+    lines = text.splitlines()
+    if lines[0] == "---":
+        lines = lines[1:]
+        text = "\n".join(lines)
+        frontmatter, _, markdown = text.partition("\n---\n")
+        return frontmatter, markdown
 
-    lines = lines.replace("\r\n", "\n")
-    for index, line in enumerate(lines.split("\n")):
-        if index == 0 and line.strip().startswith("---"):
-            splitter = fmlines
-        elif line.strip().startswith("---"):
-            splitter = mdlines
-        else:
-            splitter.append(line)
-
-    return "\n".join(fmlines), "\n".join(mdlines)
+    return "", text

--- a/vulnerabilities/importers/istio.py
+++ b/vulnerabilities/importers/istio.py
@@ -174,10 +174,8 @@ class IstioDataSource(GitDataSource):
         return advisories
 
     def get_data_from_md(self, path):
-        """Return a mapping of vulnerability data from istio. The data is
-        in the form of yaml objects found inside front matter of the .md file.
-        """
+        """Return a mapping of vulnerability data extracted from an advisory."""
 
         with open(path) as f:
-            yaml_lines, _ = split_markdown_front_matter(f.read())
-            return saneyaml.load(yaml_lines)
+            front_matter, _ = split_markdown_front_matter(f.read())
+            return saneyaml.load(front_matter)

--- a/vulnerabilities/importers/istio.py
+++ b/vulnerabilities/importers/istio.py
@@ -32,8 +32,8 @@ from univers.versions import SemverVersion
 from vulnerabilities.data_source import Advisory
 from vulnerabilities.data_source import GitDataSource
 from vulnerabilities.data_source import Reference
-from vulnerabilities.helpers import split_markdown_front_matter
 from vulnerabilities.helpers import nearest_patched_package
+from vulnerabilities.helpers import split_markdown_front_matter
 from vulnerabilities.package_managers import GitHubTagsAPI
 
 is_release = re.compile(r"^[\d.]+$", re.IGNORECASE).match


### PR DESCRIPTION
helper for istio and mozilla importers
The following two alternatives are also proposed:
```py
def split_markdown_front_matter(lines: str) -> Tuple[str, str]:
    fmlines = []
    mdlines = []
    splitter = mdlines

    for index, line in enumerate(lines.split("\n")):
        if index == 0 and line.strip().startswith("---"):
            splitter = fmlines
        elif line.strip().startswith("---"):
            splitter = mdlines
        else:
            splitter.append(line)

    return "\n".join(fmlines), "\n".join(mdlines)
```

and the one present [here](https://github.com/mozilla/foundation-security-advisories/blob/d43d09d204ab5da014e83b7d1743df289cefee92/check_advisories.py#L183-L208) under MPL license.

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>