### PR TITLE
Fix nix Github workflow

### DIFF
--- a/.github/workflows/test-import-using-nix.yml
+++ b/.github/workflows/test-import-using-nix.yml
@@ -25,5 +25,6 @@ jobs:
       - name: run checks & test import
         run: |
           cd etc/nix
+          ./get-latest-pypi-deps-db.sh --in-place
           nix --print-build-logs flake check
           ./test-import-using-nix.sh alpine

--- a/etc/nix/get-latest-pypi-deps-db.sh
+++ b/etc/nix/get-latest-pypi-deps-db.sh
@@ -7,6 +7,16 @@ COMMIT=$(sed '1q;d' <<< "$DATA")
 DATE=$(sed '2q;d' <<< "$DATA")
 SHA256=$(nix-prefetch-url --unpack --type sha256 "https://github.com/$USER_SLASH_REPO/tarball/$COMMIT" | tail -n 1)
 
+NIX_REV_ATTR="pypiDataRev = \"$COMMIT\"; # $DATE"
+NIX_SHA_ATTR="pypiDataSha256 = \"$SHA256\";"
+
 echo ""
-echo "pypiDataRev = \"$COMMIT\"; # $DATE"
-echo "pypiDataSha256 = \"$SHA256\";"
+echo $NIX_REV_ATTR
+echo $NIX_SHA_ATTR
+
+if [[ "$1" = "--in-place" ]] ; then
+  # Replace the values in the flake.
+  PATTERN="\s*\n?\s*\"[^\n]+" # <space><newline><space>"content...<newline>
+  perl -i.bak1 -0777 -pe "s/pypiDataRev =$PATTERN/$NIX_REV_ATTR/" flake.nix
+  perl -i.bak2 -0777 -pe "s/pypiDataSha256 =$PATTERN/$NIX_SHA_ATTR/" flake.nix
+fi


### PR DESCRIPTION
This PR automatically fetches the latest [pypi-deps-db](https://github.com/DavHau/pypi-deps-db) before running the automated Nix tests (Github Action). This does *not* commit the changes. However, this should make the nix tests keep running (on Github) when the ``requirements.txt`` change and the obvious fix is to fetch a new version of pypi-deps-db.