### PR TITLE
Continue importing from github on InvalidVersion

### DIFF
--- a/vulnerabilities/tests/test_github.py
+++ b/vulnerabilities/tests/test_github.py
@@ -63,7 +63,7 @@ class TestGitHubAPIDataSource(TestCase):
 
     def test_categorize_versions(self):
         eg_version_range = ">= 3.3.0, < 3.3.5"
-        eg_versions = ["3.3.6", "3.3.0", "3.3.4", "3.2.0"]
+        eg_versions = ["3.3.6", "3.3.0", "3.3.4", "3.2.0", "0.1-charmander"]
 
         aff_vers, safe_vers = self.data_src.categorize_versions(
             "pypi", eg_version_range, eg_versions


### PR DESCRIPTION
GitHub seems to return versions which `universe` considers invalid. This change catches the exceptions and continues importing.

Please excuse my Python if I've done anything goofy - it's not a language I speak that often (I'm doing mostly Clojure these days).

Below are some that I saw on a recent run:

```
Invalid version: -class.-jw.util.version.Version-
Invalid version: 2013-12-23T17-51-15
Invalid version: 2013-02-08T17:40:57+0000
Invalid version: 2013-05-09T12:47:53+0200
Invalid version: 2013-07-19T09:11:08+0000
Invalid version: 2013-02-02T19:59:03+0100
Invalid version: 2013-06-01T10:32:51+0200
Invalid version: 2013-02-02T20:23:17+0100
Invalid version: 2013-08-12T21:48:56+0200
Invalid version: 2013-05-14T20:16:05+0200
Invalid version: 2013-02-01T20:50:46+0100
Invalid version: 2013-01-23T17:11:52+0100
Invalid version: 2013-01-21T20:33:09+0100
Invalid version: 2013-03-27T16:32:26+0100
Invalid version: 2013-09-11T19-27-10
Invalid version: 2013-05-10T17:55:56+0200
Invalid version: 2014-01-12T15-52-10
Invalid version: 2.0.1rc2-git
Invalid version: 0.7.11p2
Invalid version: 0.8.1p1
Invalid version: 0.8.4p1
Invalid version: 0.7.11p1
Invalid version: 0.7.10p1
Invalid version: 0.8.6p1
Invalid version: 0.8.7p1
Invalid version: 0.8.4p2
Invalid version: 0.7.11p3
Invalid version: 0.8.3p1
Invalid version: 0.7.11p2
Invalid version: 0.8.1p1
Invalid version: 0.8.4p1
Invalid version: 0.7.11p1
Invalid version: 0.7.10p1
Invalid version: 0.8.6p1
Invalid version: 0.8.7p1
Invalid version: 0.8.4p2
Invalid version: 0.7.11p3
Invalid version: 0.8.3p1
Invalid version: 3.0b6dev-r41684
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 3.0.0b3-
Invalid version: 0.6m2
Invalid version: 0.4m1
Invalid version: 0.4m5
Invalid version: 0.3m5
Invalid version: 0.6m3
Invalid version: 0.5m3
Invalid version: 0.5m5
Invalid version: 0.5m2
Invalid version: 0.4m3
Invalid version: 0.5m1
Invalid version: 0.3m3
Invalid version: 0.5m4
Invalid version: 0.6m4
Invalid version: 0.6m6
Invalid version: 0.4m2
Invalid version: 0.3m1
Invalid version: 0.3m4
Invalid version: 0.3m2
Invalid version: 0.4m4
Invalid version: 0.6m5
Invalid version: 0.6m1
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
Invalid version: 0.9-ivysaur
Invalid version: 0.9-eevee
Invalid version: 0.1-bulbasaur
Invalid version: 0.9-fearow
Invalid version: 0.9-horsea
Invalid version: 0.9-gyarados
Invalid version: 0.9-doduo
Invalid version: 0.1-charmander
```