### PR TITLE
Use svn to collects tags in GitHubTagsAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ toml>=0.10.2
 lxml>=4.6.3
 gunicorn>=20.1.0
 django-environ==0.4.5
+defusedxml==0.7.1


### PR DESCRIPTION
Surprisingly, GitHub allows svn requests to repositories. Now we can
have all the tags with a single request. This is much more efficient and
gentle to the APIs.

@pombredanne thank you so much for the suggestion

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>