### PR TITLE
Make upstream tests use makefile

### DIFF
--- a/.github/workflows/upstream_test.yml
+++ b/.github/workflows/upstream_test.yml
@@ -8,44 +8,26 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
 
-    services:
-      # Label used to access the service container
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: vulnerablecode
-          POSTGRES_DB: vulnerablecode
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
     steps:
-      - name: Check out repository code
+      - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.8.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.8.11
 
       - name: Install dependencies
         run: |
-          sudo apt install  python3-dev postgresql libpq-dev build-essential libxml2-dev libxslt1-dev 
-          python -m pip install --upgrade pip 
-          pip install -r requirements.txt -r requirements-dev.txt
-          pip install pytest-xdist
-    
-      - name: Run tests
+          sudo apt-get install -y postgresql python3-dev libpq-dev build-essential
+          make dev envfile
+
+      - name: Setup database
         run: |
-          python -m pytest -v vulnerabilities/tests/test_upstream.py -n 2
+          sudo systemctl start postgresql
+          make postgres
+    
+      - name: Run upstream tests
+        run: make webtest
         env:
-          # The hostname, username used to communicate with the PostgreSQL service container
-          POSTGRES_HOST: localhost
-          VC_DB_USER: postgres
-          POSTGRES_PORT: 5432
           GH_TOKEN: 1 

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,12 @@ run:
 	${ACTIVATE} ./manage.py runserver
 
 test:
-	@echo "-> Run the test suite"
+	@echo "-> Run offline tests"
 	${ACTIVATE} ${PYTHON_EXE} -m pytest -v -m "not webtest"
+
+webtest:
+	@echo "-> Run web tests"
+	${ACTIVATE} ${PYTHON_EXE} -m pytest -v -m "webtest"
 
 package: conf
 	@echo "-> Create a VulnerableCode package for offline installation"


### PR DESCRIPTION
Refactor upstream tests to use makefile and standard installation
procedure. Also, it explicitly makes sure python version we test is
3.8.11

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>