### PR TITLE
DebianVersionAPI: automatic support for proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,6 +219,9 @@ environment variable with::
 
     export GH_TOKEN=yourgithubtoken
 
+If you are running behind a proxy, you will need to setup the standard ``https_proxy`` variable.
+
+    export https_proxy=https?://<proxy>:<port>
 
 See `GitHub docs  
 <https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token>`_ 

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -76,8 +76,10 @@ class VersionAPI:
         raise NotImplementedError
 
 
-def client_session():
-    return ClientSession(raise_for_status=True, trust_env=True)
+def client_session(**kwargs):
+    # trust_env is important so that https_proxy environment variable is used
+    # in proxy protected environments
+    return ClientSession(raise_for_status=True, trust_env=True, **kwargs)
 
 
 class LaunchpadVersionAPI(VersionAPI):
@@ -221,9 +223,7 @@ class DebianVersionAPI(VersionAPI):
     async def load_api(self, pkg_set):
         # Need to set the headers, because the Debian API upgrades
         # the connection to HTTP 2.0
-        async with ClientSession(
-            raise_for_status=True, headers={"Connection": "keep-alive"}
-        ) as session:
+        async with client_session(headers={"Connection": "keep-alive"}) as session:
             await asyncio.gather(
                 *[self.fetch(pkg, session) for pkg in pkg_set if pkg not in self.cache]
             )


### PR DESCRIPTION
the trust_env parameter is mandatory in ClientSession in order to support working behind a proxy

Fix: #556 
