### PR TITLE
Fix deprecated Django API

### DIFF
--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -25,7 +25,7 @@ from datetime import datetime
 
 from django.db import models
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from packageurl.contrib.django.models import PackageURLMixin
 from packageurl import PackageURL
 


### PR DESCRIPTION
Issue:
The application can be started in it's current state because ugettext_lazy was deprecated. See https://forum.djangoproject.com/t/importerror-cannot-import-name-ugettext-lazy-from-django-utils-translation/10943

Fix:
Replaced deprecated API with supported one

This Fixes #587 (actually, only the use of an API deprecated in Django 4.x)