### PR TITLE
Amend to_dict function for inferences

### DIFF
--- a/vulnerabilities/improver.py
+++ b/vulnerabilities/improver.py
@@ -67,14 +67,12 @@ class Inference:
         """
         return {
             "vulnerability_id": self.vulnerability_id,
-            "aliases": [alias for alias in self.aliases or []],
+            "aliases": [alias for alias in self.aliases],
             "confidence": self.confidence,
             "summary": self.summary,
-            "affected_purls": [
-                affected_purl.to_dict() for affected_purl in self.affected_purls or []
-            ],
+            "affected_purls": [affected_purl.to_dict() for affected_purl in self.affected_purls],
             "fixed_purl": self.fixed_purl.to_dict() if self.fixed_purl else None,
-            "references": [ref.to_dict() for ref in self.references or []],
+            "references": [ref.to_dict() for ref in self.references],
         }
 
     @classmethod
@@ -87,7 +85,7 @@ class Inference:
             aliases=advisory_data.aliases,
             confidence=confidence,
             summary=advisory_data.summary,
-            affected_purls=affected_purls,
+            affected_purls=affected_purls or [],
             fixed_purl=fixed_purl,
             references=advisory_data.references,
         )

--- a/vulnerabilities/improvers/default.py
+++ b/vulnerabilities/improvers/default.py
@@ -52,7 +52,7 @@ class DefaultImprover(Improver):
     def get_inferences(self, advisory_data: AdvisoryData) -> Iterable[Inference]:
 
         if not advisory_data:
-            return None
+            return []
 
         if advisory_data.affected_packages:
             for affected_package in advisory_data.affected_packages:

--- a/vulnerabilities/tests/test_default_improver.py
+++ b/vulnerabilities/tests/test_default_improver.py
@@ -1,3 +1,26 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/vulnerablecode/
+# The VulnerableCode software is licensed under the Apache License version 2.0.
+# Data generated with VulnerableCode require an acknowledgment.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with VulnerableCode or any VulnerableCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with VulnerableCode and provided on an 'AS IS' BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  VulnerableCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  VulnerableCode is a free software from nexB Inc. and others.
+#  Visit https://github.com/nexB/vulnerablecode/ for support and download.
+
 import json
 import os
 
@@ -12,7 +35,6 @@ from vulnerabilities.tests import util_tests
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DATA = os.path.join(BASE_DIR, "test_data", "default_improver")
-VULNERABLECODE_REGEN_TEST_FIXTURES = os.getenv("VULNERABLECODE_REGEN_TEST_FIXTURES", False)
 
 
 def test_default_improver_with_no_data():
@@ -45,7 +67,7 @@ def test_default_improver_with_empty_affected_packages():
         aliases=["CVE-2020-1234"],
         confidence=100,
         summary="Test summary",
-        affected_purls=None,
+        affected_purls=[],
         fixed_purl=None,
         references=[Reference(reference_id="", url="https://www.example.com/", severities=[])],
     )
@@ -100,13 +122,13 @@ def test_default_improver_with_affected_packages():
     assert result == expected
 
 
-def test_default_improver_with_alpine(regen=VULNERABLECODE_REGEN_TEST_FIXTURES):
+def test_default_improver_with_alpine():
     """
     Test that DefaultImprover.get_inferences() returns an empty list when given an advisory with alpine advisories
     """
     default_improver = DefaultImprover()
     response_file = os.path.join(TEST_DATA, f"alpine-input.json")
-    with open(response_file, "r") as f:
+    with open(response_file) as f:
         advisory_data = json.load(f)
     expected_file = os.path.join(TEST_DATA, f"alpine-expected.json")
     result = [
@@ -116,11 +138,11 @@ def test_default_improver_with_alpine(regen=VULNERABLECODE_REGEN_TEST_FIXTURES):
     util_tests.check_results_against_json(result, expected_file)
 
 
-def test_default_improver_with_nvd(regen=VULNERABLECODE_REGEN_TEST_FIXTURES):
+def test_default_improver_with_nvd():
     default_improver = DefaultImprover()
     response_file = os.path.join(TEST_DATA, f"nvd-input.json")
 
-    with open(response_file, "r") as f:
+    with open(response_file) as f:
         advisory_data = json.load(f)
     expected_file = os.path.join(TEST_DATA, f"nvd-expected.json")
     result = [


### PR DESCRIPTION
Also return an empty list instead of returning None when there is no advisory data passed in get_inferences

Signed-off-by: Tushar Goel <tushar.goel.dav@gmail.com>