### PR TITLE
Add firstPatchedVersion in github API

### DIFF
--- a/vulnerabilities/importers/github.py
+++ b/vulnerabilities/importers/github.py
@@ -320,7 +320,7 @@ def process_response(resp: dict, package_type: str) -> Iterable[AdvisoryData]:
                 logger.error(f"Unknown identifier type {identifier_type!r} and value {value!r}")
 
         yield AdvisoryData(
-            aliases=dedupe(aliases),
+            aliases=sorted(dedupe(aliases)),
             summary=summary,
             references=references,
             affected_packages=affected_packages,

--- a/vulnerabilities/importers/github.py
+++ b/vulnerabilities/importers/github.py
@@ -30,6 +30,7 @@ from typing import Optional
 from dateutil import parser as dateparser
 from django.db.models.query import QuerySet
 from packageurl import PackageURL
+from univers.version_range import RANGE_CLASS_BY_SCHEMES
 from univers.version_range import build_range_from_github_advisory_constraint
 
 from vulnerabilities import severity_systems
@@ -48,6 +49,7 @@ from vulnerabilities.package_managers import GoproxyVersionAPI
 from vulnerabilities.package_managers import VersionAPI
 from vulnerabilities.package_managers import get_api_package_name
 from vulnerabilities.utils import AffectedPackage as LegacyAffectedPackage
+from vulnerabilities.utils import dedupe
 from vulnerabilities.utils import get_affected_packages_by_patched_package
 from vulnerabilities.utils import get_item
 from vulnerabilities.utils import nearest_patched_package
@@ -153,6 +155,9 @@ query{
                     severity
                     publishedAt
                 }
+                firstPatchedVersion{
+                    identifier
+                }
                 package {
                     name
                 }
@@ -236,60 +241,64 @@ def process_response(resp: dict, package_type: str) -> Iterable[AdvisoryData]:
         return
 
     for vulnerability in vulnerabilities:
+        aliases = []
         affected_packages = []
-        aliases = set()
         github_advisory = get_item(vulnerability, "node")
         if not github_advisory:
             logger.error(f"No node found in {vulnerability!r}")
             continue
-
-        name = get_item(github_advisory, "package", "name")
-        if not name:
-            logger.error(f"No name found in {github_advisory!r}")
-            continue
-
-        purl = get_purl(pkg_type=package_type, github_name=name)
-        if not purl:
-            continue
-
-        vulnerable_range = get_item(github_advisory, "vulnerableVersionRange")
-        if not vulnerable_range:
-            logger.error(f"No affected range found in {github_advisory!r}")
-            continue
-
-        affected_range = None
-        try:
-            affected_range = build_range_from_github_advisory_constraint(
-                package_type, vulnerable_range
-            )
-        except InvalidVersionRange:
-            logger.error(f"Could not parse affected range {vulnerable_range!r}")
-            continue
-
-        if affected_range != NotImplementedError:
-            affected_packages.append(
-                AffectedPackage(
-                    package=purl,
-                    affected_version_range=affected_range,
-                )
-            )
 
         advisory = get_item(github_advisory, "advisory")
         if not advisory:
             logger.error(f"No advisory found in {github_advisory!r}")
             continue
 
+        summary = get_item(advisory, "summary") or ""
+
         references = get_item(advisory, "references") or []
         if references:
             urls = (ref["url"] for ref in references)
             references = [Reference.from_url(u) for u in urls]
 
-        summary = get_item(advisory, "summary")
+        date_published = get_item(advisory, "publishedAt")
+        if date_published:
+            date_published = dateparser.parse(date_published)
+
+        name = get_item(github_advisory, "package", "name")
+        if name:
+            purl = get_purl(pkg_type=package_type, github_name=name)
+        if purl:
+            affected_range = get_item(github_advisory, "vulnerableVersionRange")
+            fixed_version = get_item(github_advisory, "firstPatchedVersion", "identifier")
+            if affected_range:
+                try:
+                    affected_range = build_range_from_github_advisory_constraint(
+                        package_type, affected_range
+                    )
+                except InvalidVersionRange as e:
+                    logger.error(f"Could not parse affected range {affected_range!r} {e!r}")
+                    affected_range = None
+            if fixed_version:
+                try:
+                    fixed_version = RANGE_CLASS_BY_SCHEMES[package_type].version_class(
+                        fixed_version
+                    )
+                except Exception as e:
+                    logger.error(f"Invalid fixed version {fixed_version!r} {e!r}")
+                    fixed_version = None
+            if affected_range or fixed_version:
+                affected_packages.append(
+                    AffectedPackage(
+                        package=purl,
+                        affected_version_range=affected_range,
+                        fixed_version=fixed_version,
+                    )
+                )
         identifiers = get_item(advisory, "identifiers") or []
         for identifier in identifiers:
             value = identifier["value"]
             identifier_type = identifier["type"]
-            aliases.add(value)
+            aliases.append(value)
             # attach the GHSA with severity score
             if identifier_type == "GHSA":
                 # Each Node has only one GHSA, hence exit after attaching
@@ -310,12 +319,8 @@ def process_response(resp: dict, package_type: str) -> Iterable[AdvisoryData]:
             else:
                 logger.error(f"Unknown identifier type {identifier_type!r} and value {value!r}")
 
-        date_published = get_item(advisory, "publishedAt")
-        if date_published:
-            date_published = dateparser.parse(date_published)
-
         yield AdvisoryData(
-            aliases=sorted(list(aliases)),
+            aliases=dedupe(aliases),
             summary=summary,
             references=references,
             affected_packages=affected_packages,

--- a/vulnerabilities/package_managers.py
+++ b/vulnerabilities/package_managers.py
@@ -395,9 +395,6 @@ class ComposerVersionAPI(VersionAPI):
     package_type = "composer"
 
     def fetch(self, pkg: str) -> Iterable[PackageVersion]:
-        if "/" not in pkg:
-            raise Exception(f"Composer package: {pkg!r} does not have a vendor/name structure.")
-
         response = get_response(url=f"https://repo.packagist.org/p/{pkg}.json")
         if response:
             yield from self.extract_versions(response, pkg)

--- a/vulnerabilities/tests/test_data/github_api/composer-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/composer-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "GHSA-6qcc-whgp-pjj2",
-      "CVE-2022-0832"
+      "CVE-2022-0832",
+      "GHSA-6qcc-whgp-pjj2"
     ],
     "summary": "Cross-site Scripting in Pimcore",
     "affected_packages": [
@@ -50,8 +50,8 @@
   },
   {
     "aliases": [
-      "GHSA-q67f-3jq4-mww2",
-      "CVE-2022-0831"
+      "CVE-2022-0831",
+      "GHSA-q67f-3jq4-mww2"
     ],
     "summary": "Cross-site Scripting in Pimcore",
     "affected_packages": [
@@ -99,8 +99,8 @@
   },
   {
     "aliases": [
-      "GHSA-x28w-hvwc-mp75",
-      "CVE-2022-0895"
+      "CVE-2022-0895",
+      "GHSA-x28w-hvwc-mp75"
     ],
     "summary": "Static Code Injection in Microweber",
     "affected_packages": [
@@ -148,8 +148,8 @@
   },
   {
     "aliases": [
-      "GHSA-gj26-g5qf-jrh7",
-      "CVE-2022-0589"
+      "CVE-2022-0589",
+      "GHSA-gj26-g5qf-jrh7"
     ],
     "summary": "Cross-site Scripting in librenms",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/composer-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/composer-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "CVE-2022-0832",
-      "GHSA-6qcc-whgp-pjj2"
+      "GHSA-6qcc-whgp-pjj2",
+      "CVE-2022-0832"
     ],
     "summary": "Cross-site Scripting in Pimcore",
     "affected_packages": [
@@ -50,8 +50,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-0831",
-      "GHSA-q67f-3jq4-mww2"
+      "GHSA-q67f-3jq4-mww2",
+      "CVE-2022-0831"
     ],
     "summary": "Cross-site Scripting in Pimcore",
     "affected_packages": [
@@ -99,8 +99,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-0895",
-      "GHSA-x28w-hvwc-mp75"
+      "GHSA-x28w-hvwc-mp75",
+      "CVE-2022-0895"
     ],
     "summary": "Static Code Injection in Microweber",
     "affected_packages": [
@@ -148,8 +148,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-0589",
-      "GHSA-gj26-g5qf-jrh7"
+      "GHSA-gj26-g5qf-jrh7",
+      "CVE-2022-0589"
     ],
     "summary": "Cross-site Scripting in librenms",
     "affected_packages": [
@@ -163,7 +163,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:composer/<22.1.0",
-        "fixed_version": null
+        "fixed_version": "22.1.0"
       }
     ],
     "references": [

--- a/vulnerabilities/tests/test_data/github_api/composer.json
+++ b/vulnerabilities/tests/test_data/github_api/composer.json
@@ -150,6 +150,9 @@
             "package": {
               "name": "librenms/librenms"
             },
+            "firstPatchedVersion": {
+              "identifier" :"22.1.0"
+            },
             "vulnerableVersionRange": "< 22.1.0"
           }
         }

--- a/vulnerabilities/tests/test_data/github_api/gem-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/gem-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "GHSA-6mq2-37j5-w6r6",
-      "CVE-2009-4492"
+      "CVE-2009-4492",
+      "GHSA-6mq2-37j5-w6r6"
     ],
     "summary": "Moderate severity vulnerability that affects webrick",
     "affected_packages": [
@@ -85,8 +85,8 @@
   },
   {
     "aliases": [
-      "GHSA-w749-p3v6-hccq",
-      "CVE-2022-21831"
+      "CVE-2022-21831",
+      "GHSA-w749-p3v6-hccq"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -139,8 +139,8 @@
   },
   {
     "aliases": [
-      "GHSA-w749-p3v6-hccq",
-      "CVE-2022-21831"
+      "CVE-2022-21831",
+      "GHSA-w749-p3v6-hccq"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -193,8 +193,8 @@
   },
   {
     "aliases": [
-      "GHSA-w749-p3v6-hccq",
-      "CVE-2022-21831"
+      "CVE-2022-21831",
+      "GHSA-w749-p3v6-hccq"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -247,8 +247,8 @@
   },
   {
     "aliases": [
-      "GHSA-w749-p3v6-hccq",
-      "CVE-2022-21831"
+      "CVE-2022-21831",
+      "GHSA-w749-p3v6-hccq"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/gem-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/gem-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "CVE-2009-4492",
-      "GHSA-6mq2-37j5-w6r6"
+      "GHSA-6mq2-37j5-w6r6",
+      "CVE-2009-4492"
     ],
     "summary": "Moderate severity vulnerability that affects webrick",
     "affected_packages": [
@@ -16,7 +16,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:gem/<=1.3.1",
-        "fixed_version": null
+        "fixed_version": "1.3.2"
       }
     ],
     "references": [
@@ -85,8 +85,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-21831",
-      "GHSA-w749-p3v6-hccq"
+      "GHSA-w749-p3v6-hccq",
+      "CVE-2022-21831"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -139,8 +139,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-21831",
-      "GHSA-w749-p3v6-hccq"
+      "GHSA-w749-p3v6-hccq",
+      "CVE-2022-21831"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -193,8 +193,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-21831",
-      "GHSA-w749-p3v6-hccq"
+      "GHSA-w749-p3v6-hccq",
+      "CVE-2022-21831"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [
@@ -247,8 +247,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-21831",
-      "GHSA-w749-p3v6-hccq"
+      "GHSA-w749-p3v6-hccq",
+      "CVE-2022-21831"
     ],
     "summary": "Possible code injection vulnerability in Rails / Active Storage",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/gem.json
+++ b/vulnerabilities/tests/test_data/github_api/gem.json
@@ -57,6 +57,9 @@
             "package": {
               "name": "webrick"
             },
+            "firstPatchedVersion": {
+              "identifier" :"1.3.2"
+            },
             "vulnerableVersionRange": "<= 1.3.1"
           }
         },

--- a/vulnerabilities/tests/test_data/github_api/golang-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/golang-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "CVE-2014-9356",
-      "GHSA-vj3f-3286-r4pf"
+      "GHSA-vj3f-3286-r4pf",
+      "CVE-2014-9356"
     ],
     "summary": "Path Traversal in Docker",
     "affected_packages": [
@@ -16,7 +16,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:golang/<1.3.3",
-        "fixed_version": null
+        "fixed_version": "1.3.3"
       }
     ],
     "references": [
@@ -65,8 +65,8 @@
   },
   {
     "aliases": [
-      "CVE-2014-9356",
-      "GHSA-vj3f-3286-r4pf"
+      "GHSA-vj3f-3286-r4pf",
+      "CVE-2014-9356"
     ],
     "summary": "Path Traversal in Docker",
     "affected_packages": [
@@ -129,8 +129,8 @@
   },
   {
     "aliases": [
-      "CVE-2021-39183",
-      "GHSA-2hfj-cxw7-g45p"
+      "GHSA-2hfj-cxw7-g45p",
+      "CVE-2021-39183"
     ],
     "summary": "Unsafe inline XSS in pasting DOM element into chat",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/golang-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/golang-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "GHSA-vj3f-3286-r4pf",
-      "CVE-2014-9356"
+      "CVE-2014-9356",
+      "GHSA-vj3f-3286-r4pf"
     ],
     "summary": "Path Traversal in Docker",
     "affected_packages": [
@@ -65,8 +65,8 @@
   },
   {
     "aliases": [
-      "GHSA-vj3f-3286-r4pf",
-      "CVE-2014-9356"
+      "CVE-2014-9356",
+      "GHSA-vj3f-3286-r4pf"
     ],
     "summary": "Path Traversal in Docker",
     "affected_packages": [
@@ -129,8 +129,8 @@
   },
   {
     "aliases": [
-      "GHSA-2hfj-cxw7-g45p",
-      "CVE-2021-39183"
+      "CVE-2021-39183",
+      "GHSA-2hfj-cxw7-g45p"
     ],
     "summary": "Unsafe inline XSS in pasting DOM element into chat",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/golang.json
+++ b/vulnerabilities/tests/test_data/github_api/golang.json
@@ -45,6 +45,9 @@
             "package": {
               "name": "github.com/moby/moby"
             },
+            "firstPatchedVersion": {
+              "identifier" :"1.3.3"
+            },
             "vulnerableVersionRange": "< 1.3.3"
           }
         },

--- a/vulnerabilities/tests/test_data/github_api/maven-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/maven-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "GHSA-qcxh-w3j9-58qr",
-      "CVE-2019-0199"
+      "CVE-2019-0199",
+      "GHSA-qcxh-w3j9-58qr"
     ],
     "summary": "Denial of Service in Tomcat",
     "affected_packages": [
@@ -35,8 +35,8 @@
   },
   {
     "aliases": [
-      "GHSA-qcxh-w3j9-58qr",
-      "CVE-2019-0199"
+      "CVE-2019-0199",
+      "GHSA-qcxh-w3j9-58qr"
     ],
     "summary": "Denial of Service in Tomcat",
     "affected_packages": [
@@ -69,8 +69,8 @@
   },
   {
     "aliases": [
-      "GHSA-c9hw-wf7x-jp9j",
-      "CVE-2020-1938"
+      "CVE-2020-1938",
+      "GHSA-c9hw-wf7x-jp9j"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [
@@ -103,8 +103,8 @@
   },
   {
     "aliases": [
-      "GHSA-c9hw-wf7x-jp9j",
-      "CVE-2020-1938"
+      "CVE-2020-1938",
+      "GHSA-c9hw-wf7x-jp9j"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [
@@ -137,8 +137,8 @@
   },
   {
     "aliases": [
-      "GHSA-c9hw-wf7x-jp9j",
-      "CVE-2020-1938"
+      "CVE-2020-1938",
+      "GHSA-c9hw-wf7x-jp9j"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/maven-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/maven-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "CVE-2019-0199",
-      "GHSA-qcxh-w3j9-58qr"
+      "GHSA-qcxh-w3j9-58qr",
+      "CVE-2019-0199"
     ],
     "summary": "Denial of Service in Tomcat",
     "affected_packages": [
@@ -35,8 +35,8 @@
   },
   {
     "aliases": [
-      "CVE-2019-0199",
-      "GHSA-qcxh-w3j9-58qr"
+      "GHSA-qcxh-w3j9-58qr",
+      "CVE-2019-0199"
     ],
     "summary": "Denial of Service in Tomcat",
     "affected_packages": [
@@ -69,8 +69,8 @@
   },
   {
     "aliases": [
-      "CVE-2020-1938",
-      "GHSA-c9hw-wf7x-jp9j"
+      "GHSA-c9hw-wf7x-jp9j",
+      "CVE-2020-1938"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [
@@ -103,8 +103,8 @@
   },
   {
     "aliases": [
-      "CVE-2020-1938",
-      "GHSA-c9hw-wf7x-jp9j"
+      "GHSA-c9hw-wf7x-jp9j",
+      "CVE-2020-1938"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [
@@ -137,8 +137,8 @@
   },
   {
     "aliases": [
-      "CVE-2020-1938",
-      "GHSA-c9hw-wf7x-jp9j"
+      "GHSA-c9hw-wf7x-jp9j",
+      "CVE-2020-1938"
     ],
     "summary": "Improper Input Validation in Tomcat",
     "affected_packages": [
@@ -152,7 +152,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:maven/>=9.0.0|<9.0.31",
-        "fixed_version": null
+        "fixed_version": "9.0.1"
       }
     ],
     "references": [

--- a/vulnerabilities/tests/test_data/github_api/maven.json
+++ b/vulnerabilities/tests/test_data/github_api/maven.json
@@ -139,6 +139,9 @@
             "package": {
               "name": "org.apache.tomcat.embed:tomcat-embed-core"
             },
+            "firstPatchedVersion": {
+              "identifier" :"9.0.1"
+            },
             "vulnerableVersionRange": ">= 9.0.0, < 9.0.31"
           }
         }

--- a/vulnerabilities/tests/test_data/github_api/nuget-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/nuget-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "GHSA-ph3v-2hq5-5qfq",
-      "CVE-2021-46703"
+      "CVE-2021-46703",
+      "GHSA-ph3v-2hq5-5qfq"
     ],
     "summary": "Code injection in RazorEngine",
     "affected_packages": [
@@ -45,8 +45,8 @@
   },
   {
     "aliases": [
-      "GHSA-gcx5-3p5f-f8vp",
-      "CVE-2022-23395"
+      "CVE-2022-23395",
+      "GHSA-gcx5-3p5f-f8vp"
     ],
     "summary": "Prototype Pollution in jquery.cookie",
     "affected_packages": [
@@ -89,8 +89,8 @@
   },
   {
     "aliases": [
-      "GHSA-vv6j-ww6x-54gx",
-      "CVE-2022-0609"
+      "CVE-2022-0609",
+      "GHSA-vv6j-ww6x-54gx"
     ],
     "summary": "Use after free in Animation",
     "affected_packages": [
@@ -133,8 +133,8 @@
   },
   {
     "aliases": [
-      "GHSA-j8f4-2w4p-mhjc",
-      "CVE-2017-0256"
+      "CVE-2017-0256",
+      "GHSA-j8f4-2w4p-mhjc"
     ],
     "summary": "Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/nuget-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/nuget-expected.json
@@ -1,8 +1,8 @@
 [
   {
     "aliases": [
-      "CVE-2021-46703",
-      "GHSA-ph3v-2hq5-5qfq"
+      "GHSA-ph3v-2hq5-5qfq",
+      "CVE-2021-46703"
     ],
     "summary": "Code injection in RazorEngine",
     "affected_packages": [
@@ -16,7 +16,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:nuget/<=4.5.1-alpha001",
-        "fixed_version": null
+        "fixed_version": "4.5.1"
       }
     ],
     "references": [
@@ -45,8 +45,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-23395",
-      "GHSA-gcx5-3p5f-f8vp"
+      "GHSA-gcx5-3p5f-f8vp",
+      "CVE-2022-23395"
     ],
     "summary": "Prototype Pollution in jquery.cookie",
     "affected_packages": [
@@ -89,8 +89,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-0609",
-      "GHSA-vv6j-ww6x-54gx"
+      "GHSA-vv6j-ww6x-54gx",
+      "CVE-2022-0609"
     ],
     "summary": "Use after free in Animation",
     "affected_packages": [
@@ -133,8 +133,8 @@
   },
   {
     "aliases": [
-      "CVE-2017-0256",
-      "GHSA-j8f4-2w4p-mhjc"
+      "GHSA-j8f4-2w4p-mhjc",
+      "CVE-2017-0256"
     ],
     "summary": "Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/nuget.json
+++ b/vulnerabilities/tests/test_data/github_api/nuget.json
@@ -33,6 +33,9 @@
             "package": {
               "name": "RazorEngine"
             },
+            "firstPatchedVersion": {
+              "identifier" :"4.5.1"
+            },
             "vulnerableVersionRange": "<= 4.5.1-alpha001"
           }
         },

--- a/vulnerabilities/tests/test_data/github_api/pypi-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/pypi-expected.json
@@ -15,7 +15,7 @@
           "subpath": null
         },
         "affected_version_range": "vers:pypi/<9.0.0",
-        "fixed_version": null
+        "fixed_version": "9.0.0"
       }
     ],
     "references": [
@@ -44,8 +44,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-22817",
-      "GHSA-8vj2-vxx3-667w"
+      "GHSA-8vj2-vxx3-667w",
+      "CVE-2022-22817"
     ],
     "summary": "Arbitrary expression injection in Pillow",
     "affected_packages": [
@@ -108,8 +108,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-24303",
-      "GHSA-9j59-75qj-795w"
+      "GHSA-9j59-75qj-795w",
+      "CVE-2022-24303"
     ],
     "summary": "Path traversal in Pillow",
     "affected_packages": [
@@ -157,8 +157,8 @@
   },
   {
     "aliases": [
-      "CVE-2022-23578",
-      "GHSA-8r7c-3cm2-3h8f"
+      "GHSA-8r7c-3cm2-3h8f",
+      "CVE-2022-23578"
     ],
     "summary": "Memory leak in Tensorflow",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/pypi-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/pypi-expected.json
@@ -44,8 +44,8 @@
   },
   {
     "aliases": [
-      "GHSA-8vj2-vxx3-667w",
-      "CVE-2022-22817"
+      "CVE-2022-22817",
+      "GHSA-8vj2-vxx3-667w"
     ],
     "summary": "Arbitrary expression injection in Pillow",
     "affected_packages": [
@@ -108,8 +108,8 @@
   },
   {
     "aliases": [
-      "GHSA-9j59-75qj-795w",
-      "CVE-2022-24303"
+      "CVE-2022-24303",
+      "GHSA-9j59-75qj-795w"
     ],
     "summary": "Path traversal in Pillow",
     "affected_packages": [
@@ -157,8 +157,8 @@
   },
   {
     "aliases": [
-      "GHSA-8r7c-3cm2-3h8f",
-      "CVE-2022-23578"
+      "CVE-2022-23578",
+      "GHSA-8r7c-3cm2-3h8f"
     ],
     "summary": "Memory leak in Tensorflow",
     "affected_packages": [

--- a/vulnerabilities/tests/test_data/github_api/pypi.json
+++ b/vulnerabilities/tests/test_data/github_api/pypi.json
@@ -29,6 +29,9 @@
             "package": {
               "name": "Pillow"
             },
+            "firstPatchedVersion": {
+              "identifier" :"9.0.0"
+            },
             "vulnerableVersionRange": "< 9.0.0"
           }
         },

--- a/vulnerabilities/tests/test_utils.py
+++ b/vulnerabilities/tests/test_utils.py
@@ -23,6 +23,7 @@
 from packageurl import PackageURL
 
 from vulnerabilities.utils import AffectedPackage
+from vulnerabilities.utils import get_item
 from vulnerabilities.utils import nearest_patched_package
 from vulnerabilities.utils import split_markdown_front_matter
 
@@ -94,3 +95,17 @@ cves: [CVE-2042-1337]""",
 
     results = split_markdown_front_matter(text)
     assert results == expected
+
+
+def test_get_item():
+    d1 = {"a": {"b": {"c": None}}}
+    assert get_item(d1, "a", "b", "c", "d") == None
+    d2 = {"a": {"b": {"c": {"d": None}}}}
+    assert get_item(d2, "a", "b", "c", "e") == None
+    d3 = ["a", "b", "c", "d"]
+    assert get_item(d3, "a", "b") == None
+    d4 = {"a": {"b": {"c": {"d": []}}}}
+    assert get_item(d4, "a", "b", "c", "d", "e") == None
+    d5 = {"a": {"b": {"c": "d"}}}
+    assert get_item(d5, "a", "b", "c", "d") == None
+    assert get_item(d5, "a", "b", "c") == "d"

--- a/vulnerabilities/utils.py
+++ b/vulnerabilities/utils.py
@@ -220,9 +220,12 @@ def get_item(dictionary: dict, *attributes):
     for attribute in attributes:
         if not dictionary:
             return
+        if not isinstance(dictionary, dict):
+            logger.error("dictionary must be of type `dict`")
+            return
         if attribute not in dictionary:
             logger.error(f"Missing attribute {attribute} in {dictionary}")
-            return None
+            return
         dictionary = dictionary[attribute]
     return dictionary
 

--- a/vulnerabilities/utils.py
+++ b/vulnerabilities/utils.py
@@ -217,9 +217,9 @@ def get_item(dictionary: dict, *attributes):
     'd'
     >>> assert(get_item({'a': {'b': {'c': 'd'}}}, 'a', 'b', 'e')) == None
     """
-    if not dictionary:
-        return
     for attribute in attributes:
+        if not dictionary:
+            return
         if attribute not in dictionary:
             logger.error(f"Missing attribute {attribute} in {dictionary}")
             return None


### PR DESCRIPTION
The GitHub importer failed to parse Composer packages who did not have a slash in their names. We now no longer raise an exception if a Composer package does not have "vendor/name" but only a plain name.

Also we were not getting the first patched version from the GitHub API using GraphQL. This PR is also fixing this.

Reference: https://github.com/nexb/vulnerablecode/issues/645
Signed-off-by: Tushar Goel <tushar.goel.dav@gmail.com>