### PR TITLE
fix a bug in postgresql importer

### DIFF
--- a/vulnerabilities/importers/postgresql.py
+++ b/vulnerabilities/importers/postgresql.py
@@ -80,7 +80,7 @@ def to_advisories(data):
             # This is for the anomaly in https://www.postgresql.org/support/security/8.1/ 's
             # last entry
         except IndexError:
-            pass
+            continue
 
         references = []
         vector_link_tag = severity_score_col.find("a")


### PR DESCRIPTION
I think `pass` on line 83 should be `continue`, or it will cause an exception on line 112 where `cve_id` is referenced but not defined

Signed-off-by: 司芳源 <sify21@163.com>