### PR TITLE
Fix affected package merge functionality

### DIFF
--- a/vulnerabilities/importer.py
+++ b/vulnerabilities/importer.py
@@ -188,7 +188,7 @@ class AffectedPackage:
             purls.add(pkg.package)
         if len(purls) > 1:
             raise UnMergeablePackageError("Cannot merge with different purls", purls)
-        return purls.pop(), sorted(affected_version_ranges), sorted(fixed_versions)
+        return purls.pop(), list(affected_version_ranges), sorted(fixed_versions)
 
     def to_dict(self):
         """

--- a/vulnerabilities/tests/test_affected_package.py
+++ b/vulnerabilities/tests/test_affected_package.py
@@ -57,6 +57,19 @@ def test_affected_package_merge():
                 ),
             ),
             AffectedPackage(package=PackageURL(type="npm", name="foo"), fixed_version="2.0.0"),
+            AffectedPackage(
+                package=PackageURL(type="npm", name="foo"),
+                affected_version_range=GemVersionRange(
+                    constraints=(
+                        VersionConstraint(
+                            comparator=">=", version=RubygemsVersion(string="10.2.0")
+                        ),
+                        VersionConstraint(
+                            comparator="<=", version=RubygemsVersion(string="10.5.0")
+                        ),
+                    )
+                ),
+            ),
         ]
     )
     expected = (
@@ -69,7 +82,13 @@ def test_affected_package_merge():
                     VersionConstraint(comparator=">=", version=RubygemsVersion(string="5.2.0")),
                     VersionConstraint(comparator="<=", version=RubygemsVersion(string="5.2.6.2")),
                 )
-            )
+            ),
+            GemVersionRange(
+                constraints=(
+                    VersionConstraint(comparator=">=", version=RubygemsVersion(string="10.2.0")),
+                    VersionConstraint(comparator="<=", version=RubygemsVersion(string="10.5.0")),
+                )
+            ),
         ],
         ["1.0.0", "2.0.0"],
     )

--- a/vulnerabilities/tests/test_data/github_api/inference-expected.json
+++ b/vulnerabilities/tests/test_data/github_api/inference-expected.json
@@ -424,5 +424,67 @@
       }
     ],
     "weaknesses": []
+  },
+  {
+    "vulnerability_id": null,
+    "aliases": [
+      "CVE-2022-21831",
+      "GHSA-w749-p3v6-hccq"
+    ],
+    "confidence": 100,
+    "summary": "Possible code injection vulnerability in Rails / Active Storage",
+    "affected_purls": [
+      {
+        "type": "gem",
+        "namespace": null,
+        "name": "activestorage",
+        "version": "10.2.1",
+        "qualifiers": null,
+        "subpath": null
+      },
+      {
+        "type": "gem",
+        "namespace": null,
+        "name": "activestorage",
+        "version": "10.2.8",
+        "qualifiers": null,
+        "subpath": null
+      }
+    ],
+    "fixed_purl": null,
+    "references": [
+      {
+        "reference_id": "",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-21831",
+        "severities": []
+      },
+      {
+        "reference_id": "",
+        "url": "https://github.com/rails/rails/commit/0a72f7d670e9aa77a0bb8584cb1411ddabb7546e",
+        "severities": []
+      },
+      {
+        "reference_id": "",
+        "url": "https://groups.google.com/g/rubyonrails-security/c/n-p-W1yxatI",
+        "severities": []
+      },
+      {
+        "reference_id": "",
+        "url": "https://rubysec.com/advisories/CVE-2022-21831/",
+        "severities": []
+      },
+      {
+        "reference_id": "GHSA-w749-p3v6-hccq",
+        "url": "https://github.com/advisories/GHSA-w749-p3v6-hccq",
+        "severities": [
+          {
+            "system": "cvssv3.1_qr",
+            "value": "HIGH",
+            "scoring_elements": ""
+          }
+        ]
+      }
+    ],
+    "weaknesses": []
   }
 ]

--- a/vulnerabilities/tests/test_github.py
+++ b/vulnerabilities/tests/test_github.py
@@ -172,6 +172,8 @@ def valid_versions():
         "6.0.3.4",
         "6.0.3.rc1",
         "6.0.2.rc2",
+        "10.2.8",
+        "10.2.1",
     ]
 
 
@@ -203,7 +205,27 @@ def test_github_improver(mock_response, regen=REGEN):
                     )
                 ),
                 fixed_version=None,
-            )
+            ),
+            AffectedPackage(
+                package=PackageURL(
+                    type="gem",
+                    namespace=None,
+                    name="activestorage",
+                    version=None,
+                    qualifiers={},
+                    subpath=None,
+                ),
+                affected_version_range=GemVersionRange(
+                    constraints=(
+                        VersionConstraint(
+                            comparator=">=", version=RubygemsVersion(string="10.2.0")
+                        ),
+                        VersionConstraint(
+                            comparator="<=", version=RubygemsVersion(string="10.2.8")
+                        ),
+                    )
+                ),
+            ),
         ],
         references=[
             Reference(


### PR DESCRIPTION
Affected version range does not support sort functionality, the merge function works fine if there is a single affected version range but fails for multiple affected version ranges.