### PR TITLE
Remove weaknesses from view which are not in DB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Release notes
 =============
 
 
+Next Release
+------------
+
+- We filtered out the weakness that are not presented in the 
+  cwe2.database before passing them into the vulnerability details view. 
+
+
 Version v33.2.0
 -----------------
 

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -276,16 +276,26 @@ class Weakness(models.Model):
     db = Database()
 
     @property
+    def weakness(self):
+        """
+        Return a queryset of Weakness for this vulnerability.
+        """
+        try:
+            weakness = self.db.get(self.cwe_id)
+            return weakness
+        except Exception as e:
+            logger.warning(f"Could not find CWE {self.cwe_id}: {e}")
+            return None
+
+    @property
     def name(self):
         """Return the weakness's name."""
-        weakness = self.db.get(self.cwe_id)
-        return weakness.name
+        return self.weakness.name if self.weakness else ""
 
     @property
     def description(self):
         """Return the weakness's description."""
-        weakness = self.db.get(self.cwe_id)
-        return weakness.description
+        return self.weakness.description if self.weakness else ""
 
 
 class VulnerabilityReferenceQuerySet(BaseQuerySet):

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -285,7 +285,6 @@ class Weakness(models.Model):
             return weakness
         except Exception as e:
             logger.warning(f"Could not find CWE {self.cwe_id}: {e}")
-            return None
 
     @property
     def name(self):

--- a/vulnerabilities/tests/test_models.py
+++ b/vulnerabilities/tests/test_models.py
@@ -88,3 +88,9 @@ class TestPackageRelatedVulnerablity(TestCase):
 
         assert v1.vulnerable_packages.all()[0] == p1
         assert v1.patched_packages.all()[0] == p2
+
+    def test_cwe_not_present_in_weaknesses_db(self):
+        w1 = models.Weakness.objects.create(name="189")
+        assert w1.weakness is None
+        assert w1.name is ""
+        assert w1.description is ""

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -117,7 +117,9 @@ class VulnerabilityDetails(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         weaknesses = self.object.weaknesses.all()
-        weaknesses_present_in_db = [weakness for weakness in weaknesses if weakness.weakness]
+        weaknesses_present_in_db = [
+            weakness_object for weakness_object in weaknesses if weakness_object.weakness
+        ]
         context.update(
             {
                 "vulnerability": self.object,

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -116,6 +116,8 @@ class VulnerabilityDetails(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        weaknesses = self.object.weaknesses.all()
+        weaknesses_present_in_db = [weakness for weakness in weaknesses if weakness.weakness]
         context.update(
             {
                 "vulnerability": self.object,
@@ -125,7 +127,7 @@ class VulnerabilityDetails(DetailView):
                 "aliases": self.object.aliases.all(),
                 "affected_packages": self.object.affected_packages.all(),
                 "fixed_by_packages": self.object.fixed_by_packages.all(),
-                "weaknesses": self.object.weaknesses.all(),
+                "weaknesses": weaknesses_present_in_db,
             }
         )
         return context


### PR DESCRIPTION
The problem with the CWE data is that there is no error handling when we try to access weakness using this ``weakness = self.db.get(self.cwe_id)``. For say CWE-189 which is a weakness associated with CVE-2009-3389 is not present in cwe2.database.