### PR TITLE
Fix incorrect versions in GithubDataSource CVE

### DIFF
--- a/vulntotal/datasources/github.py
+++ b/vulntotal/datasources/github.py
@@ -68,8 +68,8 @@ class GithubDataSource(DataSource):
             yield VendorData(
                 purl=purl,
                 aliases=sorted(list(set(advisory.get("identifiers", None)))),
-                affected_versions=sorted(list(set(advisory.get("firstPatchedVersion", None)))),
-                fixed_versions=sorted(list(set(advisory.get("vulnerableVersionRange", None)))),
+                affected_versions=sorted(list(set(advisory.get("vulnerableVersionRange", None)))),
+                fixed_versions=sorted(list(set(advisory.get("firstPatchedVersion", None)))),
             )
 
     @classmethod


### PR DESCRIPTION
Fixes #1398 

Changes made : 
- Patched code in  datasource_advisory_from_cve function in GithubDataSource so that correct versions are displayed