### PR TITLE
Update VulnTotal Github Datasource

### DIFF
--- a/vulntotal/datasources/github.py
+++ b/vulntotal/datasources/github.py
@@ -11,7 +11,7 @@ import logging
 from typing import Iterable
 
 from dotenv import load_dotenv
-from fetchcode.package_versions import github_response
+from fetchcode.utils import github_response
 from packageurl import PackageURL
 
 from vulntotal.validator import DataSource


### PR DESCRIPTION
Fix #1499 

There was an incorrect import path in the vulntotal/datasources/github.py file. The previous import statement:
```
from fetchcode.package_versions import github_response
```
it was updated to:
```
from fetchcode.utils import github_response
```
