### PR TITLE
Rename "Fixed by vulnerabilities" column

### DIFF
--- a/vulnerabilities/templates/packages.html
+++ b/vulnerabilities/templates/packages.html
@@ -48,7 +48,7 @@ VulnerableCode Package Search
                             <span
                                 class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
                                 data-tooltip="This is the number of vulnerabilities fixed by the package.">
-                                <span class="affected-fixed">Fixed by</span> vulnerabilities
+                                <span class="affected-fixed">Fixed</span> vulnerabilities
                             </span>
                         </th>
                     </tr>


### PR DESCRIPTION
Reference: https://github.com/nexB/vulnerablecode/issues/1501
Reference: https://github.com/nexB/vulnerablecode/issues/1520

@pombredanne @TG1999 -- ready for your review.

Note that when I ran `make test` locally, 1 test, unrelated to my update, failed:

```
FAILED vulnerabilities/tests/test_github_osv.py::GithubOSVImporter::test_github_osv_importer7 - TypeError: unhashable type: 'Version'
```

The updated column now looks like this:

![image](https://github.com/user-attachments/assets/2f6fb3c1-ebd3-4c5d-bd98-63bca46bbe0a)
