### PR TITLE
Finish renaming the former 'Fixed by vulnerabilities' column

### DIFF
--- a/vulnerabilities/templates/packages.html
+++ b/vulnerabilities/templates/packages.html
@@ -48,7 +48,7 @@ VulnerableCode Package Search
                             <span
                                 class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
                                 data-tooltip="This is the number of vulnerabilities fixed by the package.">
-                                <span class="affected-fixed">Fixed</span> vulnerabilities
+                                <span class="affected-fixed">Fixing</span> vulnerabilities
                             </span>
                         </th>
                     </tr>


### PR DESCRIPTION
Reference: https://github.com/nexB/vulnerablecode/issues/1520
Related prior issue: https://github.com/nexB/vulnerablecode/issues/1501
Updates: https://github.com/nexB/vulnerablecode/pull/1519

@pombredanne  This supplements https://github.com/nexB/vulnerablecode/pull/1519, which did not yet include today's update.

The updated Package search response page:

![image](https://github.com/user-attachments/assets/965b61c5-80d9-4b82-a8ca-a93f2a0a030c)
