### PR TITLE
Improve performance of API calls #1538

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,7 @@ dev =
     commoncode
     # debug
     django-debug-toolbar
+    pyinstrument
 
 [options.entry_points]
 console_scripts =

--- a/vulnerabilities/tests/test_api.py
+++ b/vulnerabilities/tests/test_api.py
@@ -173,7 +173,7 @@ class TestSerializers(TransactionTestCase):
         self.client.credentials(HTTP_AUTHORIZATION=self.auth)
 
     def test_package_serializer(self):
-        pk = Package.objects.filter(name="mimetex")
+        pk = Package.objects.filter(name="mimetex").with_is_vulnerable()
         mock_request = RequestFactory().get("/api")
         response = PackageSerializer(pk, many=True, context={"request": mock_request}).data
         self.assertEqual(1, len(response))
@@ -344,6 +344,48 @@ class APITestCaseVulnerability(TransactionTestCase):
         }
 
 
+def set_as_affected_by(package, vulnerability):
+    """
+    Set the ``package`` Package as affected by the ``vulnerability`` Vulnerability.
+    """
+    _set_pkg_as(package, vulnerability, fixing=False)
+
+
+def set_as_fixing(package, vulnerability):
+    """
+    Set the ``package`` Package as fixing the ``vulnerability`` Vulnerability.
+    """
+    _set_pkg_as(package, vulnerability, fixing=True)
+
+
+def _set_pkg_as(package, vulnerability, fixing=False):
+    """
+    Set the ``package`` Package as affected or fixing the ``vulnerability`` Vulnerability.
+    """
+    PackageRelatedVulnerability.objects.create(
+        package=package,
+        vulnerability=vulnerability,
+        fix=fixing,
+    )
+
+
+def create_vuln(vcid, aliases=()):
+    """
+    Return a test Vulnerability using the ``vcid`` string as VCID, using optional aliases.
+    """
+    vuln = Vulnerability.objects.create(summary=f"This is {vcid}", vulnerability_id=vcid)
+    add_aliases(vuln, aliases)
+    return vuln
+
+
+def add_aliases(vuln, aliases):
+    """
+    Add aliases to ``vuln`` Vulnerability.
+    """
+    for alias in aliases:
+        Alias.objects.create(alias=alias, vulnerability=vuln)
+
+
 class APITestCasePackage(TestCase):
     def setUp(self):
         self.user = ApiUser.objects.create_api_user(username="e@mail.com")
@@ -351,134 +393,49 @@ class APITestCasePackage(TestCase):
         self.csrf_client = APIClient(enforce_csrf_checks=True)
         self.csrf_client.credentials(HTTP_AUTHORIZATION=self.auth)
 
-        # searched-for pkg
-        self.package_maven_jackson_databind_2_13_1 = Package.objects.create(
-            type="maven",
-            namespace="com.fasterxml.jackson.core",
-            name="jackson-databind",
-            version="2.13.1",
-            qualifiers={},
-            subpath="",
-        )
+        # This setup creates the following data:
+        # vulnerabilities: vul1, vul2, vul3
+        # pkg:maven/com.fasterxml.jackson.core/jackson-databind
+        # with these versions:
+        # pkg_2_12_6:     @ 2.12.6       affected by        fixing vul3
+        # pkg_2_12_6_1:   @ 2.12.6.1     affected by vul2   fixing vul1
+        # pkg_2_13_1:     @ 2.13.1       affected by vul1   fixing vul3
+        # pkg_2_13_2:     @ 2.13.2       affected by vul2   fixing vul1
+        # pkg_2_14_0_rc1: @ 2.14.0-rc1   affected by        fixing
 
         # searched-for pkg's vuln
-        self.vuln_VCID_2nyb_8rwu_aaag = Vulnerability.objects.create(
-            summary="This is VCID-2nyb-8rwu-aaag",
-            vulnerability_id="VCID-2nyb-8rwu-aaag",
-        )
+        self.vul1 = create_vuln("VCID-vul1-vul1-vul1", ["CVE-2020-36518", "GHSA-57j2-w4cx-62h2"])
+        self.vul2 = create_vuln("VCID-vul2-vul2-vul2")
+        # This is the vuln fixed by the searched-for pkg -- and by a lesser version (created below),
+        # which WILL be included in the API
+        self.vul3 = create_vuln("VCID-vul3-vul3-vul3", ["CVE-2021-46877", "GHSA-3x8x-79m2-3w2w"])
 
-        # pkg-vuln affect relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_13_1,
-            vulnerability=self.vuln_VCID_2nyb_8rwu_aaag,
-            fix=False,
-        )
-
-        # vuln aliases
-        Alias.objects.create(alias="CVE-2020-36518", vulnerability=self.vuln_VCID_2nyb_8rwu_aaag)
-        Alias.objects.create(
-            alias="GHSA-57j2-w4cx-62h2", vulnerability=self.vuln_VCID_2nyb_8rwu_aaag
-        )
-
-        # pkg (1 of 2 -- this is a lesser version and will be omitted from the API) that fixes searched-for pkg's vuln
-        self.package_maven_jackson_databind_2_12_6_1 = Package.objects.create(
-            type="maven",
-            namespace="com.fasterxml.jackson.core",
-            name="jackson-databind",
-            version="2.12.6.1",
-            qualifiers={},
-            subpath="",
-        )
-
-        # pkg-vuln fix relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_12_6_1,
-            vulnerability=self.vuln_VCID_2nyb_8rwu_aaag,
-            fix=True,
-        )
-
-        # fixed by pkg own vuln
-        self.vuln_VCID_gqhw_ngh8_aaap = Vulnerability.objects.create(
-            summary="This is VCID-gqhw-ngh8-aaap",
-            vulnerability_id="VCID-gqhw-ngh8-aaap",
-        )
-
-        # pkg-vuln affect relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_12_6_1,
-            vulnerability=self.vuln_VCID_gqhw_ngh8_aaap,
-            fix=False,
-        )
-
-        # pkg (2 of 2 -- this is a greater version) that fixes searched-for pkg's vuln
-        self.package_maven_jackson_databind_2_13_2 = Package.objects.create(
-            type="maven",
-            namespace="com.fasterxml.jackson.core",
-            name="jackson-databind",
-            version="2.13.2",
-            qualifiers={},
-            subpath="",
-        )
-
-        # pkg-vuln fix relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_13_2,
-            vulnerability=self.vuln_VCID_2nyb_8rwu_aaag,
-            fix=True,
-        )
-
-        # pkg-vuln affect relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_13_2,
-            vulnerability=self.vuln_VCID_gqhw_ngh8_aaap,
-            fix=False,
-        )
-
-        # This is the vuln fixed by the searched-for pkg -- and by a lesser version (created below), which WILL be included in the API
-        self.vuln_VCID_ftmk_wbwx_aaar = Vulnerability.objects.create(
-            summary="This is VCID-ftmk-wbwx-aaar",
-            vulnerability_id="VCID-ftmk-wbwx-aaar",
-        )
-
-        # searched-for pkg-vuln fix relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_13_1,
-            vulnerability=self.vuln_VCID_ftmk_wbwx_aaar,
-            fix=True,
-        )
-
+        from_purl = Package.objects.from_purl
         # lesser-version pkg that also fixes the vuln fixed by the searched-for pkg
-        self.package_maven_jackson_databind_2_12_6 = Package.objects.create(
-            type="maven",
-            namespace="com.fasterxml.jackson.core",
-            name="jackson-databind",
-            version="2.12.6",
-            qualifiers={},
-            subpath="",
+        self.pkg_2_12_6 = from_purl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.12.6")
+        # this is a lesser version omitted from the API that fixes searched-for pkg's vuln
+        self.pkg_2_12_6_1 = from_purl(
+            "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.12.6.1"
         )
-
-        # lesser-version pkg-vuln fix relationship
-        PackageRelatedVulnerability.objects.create(
-            package=self.package_maven_jackson_databind_2_12_6,
-            vulnerability=self.vuln_VCID_ftmk_wbwx_aaar,
-            fix=True,
-        )
-
-        # aliases for vuln fixed by searched-for pkg
-        Alias.objects.create(alias="CVE-2021-46877", vulnerability=self.vuln_VCID_ftmk_wbwx_aaar)
-        Alias.objects.create(
-            alias="GHSA-3x8x-79m2-3w2w", vulnerability=self.vuln_VCID_ftmk_wbwx_aaar
-        )
-
+        # searched-for pkg
+        self.pkg_2_13_1 = from_purl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1")
+        # this is a greater version that fixes searched-for pkg's vuln
+        self.pkg_2_13_2 = from_purl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2")
         # This addresses both next and latest non-vulnerable pkg
-        self.package_maven_jackson_databind_2_14_0_rc1 = Package.objects.create(
-            type="maven",
-            namespace="com.fasterxml.jackson.core",
-            name="jackson-databind",
-            version="2.14.0-rc1",
-            qualifiers={},
-            subpath="",
+        self.pkg_2_14_0_rc1 = from_purl(
+            "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.0-rc1"
         )
+
+        set_as_fixing(package=self.pkg_2_12_6, vulnerability=self.vul3)
+
+        set_as_affected_by(package=self.pkg_2_12_6_1, vulnerability=self.vul2)
+        set_as_fixing(package=self.pkg_2_12_6_1, vulnerability=self.vul1)
+
+        set_as_affected_by(package=self.pkg_2_13_1, vulnerability=self.vul1)
+        set_as_fixing(package=self.pkg_2_13_1, vulnerability=self.vul3)
+
+        set_as_affected_by(package=self.pkg_2_13_2, vulnerability=self.vul2)
+        set_as_fixing(package=self.pkg_2_13_2, vulnerability=self.vul1)
 
     def test_api_with_package_with_no_vulnerabilities(self):
         affected_vulnerabilities = []
@@ -494,12 +451,10 @@ class APITestCasePackage(TestCase):
         assert package_with_no_vulnerabilities is None
 
     def test_api_with_lesser_and_greater_fixed_by_packages(self):
-        response = self.csrf_client.get(
-            f"/api/packages/{self.package_maven_jackson_databind_2_13_1.id}", format="json"
-        ).data
+        response = self.csrf_client.get(f"/api/packages/{self.pkg_2_13_1.id}", format="json").data
 
         expected_response = {
-            "url": f"http://testserver/api/packages/{self.package_maven_jackson_databind_2_13_1.id}",
+            "url": f"http://testserver/api/packages/{self.pkg_2_13_1.id}",
             "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1",
             "type": "maven",
             "namespace": "com.fasterxml.jackson.core",
@@ -507,6 +462,7 @@ class APITestCasePackage(TestCase):
             "version": "2.13.1",
             "qualifiers": {},
             "subpath": "",
+            "is_vulnerable": True,
             "next_non_vulnerable_version": "2.14.0-rc1",
             "latest_non_vulnerable_version": "2.14.0-rc1",
             "affected_by_vulnerabilities": [
@@ -514,10 +470,10 @@ class APITestCasePackage(TestCase):
                     [
                         (
                             "url",
-                            f"http://testserver/api/vulnerabilities/{self.vuln_VCID_2nyb_8rwu_aaag.id}",
+                            f"http://testserver/api/vulnerabilities/{self.vul1.id}",
                         ),
-                        ("vulnerability_id", "VCID-2nyb-8rwu-aaag"),
-                        ("summary", "This is VCID-2nyb-8rwu-aaag"),
+                        ("vulnerability_id", "VCID-vul1-vul1-vul1"),
+                        ("summary", "This is VCID-vul1-vul1-vul1"),
                         ("references", []),
                         (
                             "fixed_packages",
@@ -526,7 +482,7 @@ class APITestCasePackage(TestCase):
                                     [
                                         (
                                             "url",
-                                            f"http://testserver/api/packages/{self.package_maven_jackson_databind_2_13_2.id}",
+                                            f"http://testserver/api/packages/{self.pkg_2_13_2.id}",
                                         ),
                                         (
                                             "purl",
@@ -535,7 +491,7 @@ class APITestCasePackage(TestCase):
                                         ("is_vulnerable", True),
                                         (
                                             "affected_by_vulnerabilities",
-                                            [{"vulnerability": "VCID-gqhw-ngh8-aaap"}],
+                                            [{"vulnerability": "VCID-vul2-vul2-vul2"}],
                                         ),
                                         (
                                             "resource_url",
@@ -546,7 +502,7 @@ class APITestCasePackage(TestCase):
                             ],
                         ),
                         ("aliases", ["CVE-2020-36518", "GHSA-57j2-w4cx-62h2"]),
-                        ("resource_url", "http://testserver/vulnerabilities/VCID-2nyb-8rwu-aaag"),
+                        ("resource_url", "http://testserver/vulnerabilities/VCID-vul1-vul1-vul1"),
                     ]
                 )
             ],
@@ -555,10 +511,10 @@ class APITestCasePackage(TestCase):
                     [
                         (
                             "url",
-                            f"http://testserver/api/vulnerabilities/{self.vuln_VCID_ftmk_wbwx_aaar.id}",
+                            f"http://testserver/api/vulnerabilities/{self.vul3.id}",
                         ),
-                        ("vulnerability_id", "VCID-ftmk-wbwx-aaar"),
-                        ("summary", "This is VCID-ftmk-wbwx-aaar"),
+                        ("vulnerability_id", "VCID-vul3-vul3-vul3"),
+                        ("summary", "This is VCID-vul3-vul3-vul3"),
                         ("references", []),
                         (
                             "fixed_packages",
@@ -567,7 +523,7 @@ class APITestCasePackage(TestCase):
                                     [
                                         (
                                             "url",
-                                            f"http://testserver/api/packages/{self.package_maven_jackson_databind_2_12_6.id}",
+                                            f"http://testserver/api/packages/{self.pkg_2_12_6.id}",
                                         ),
                                         (
                                             "purl",
@@ -585,7 +541,7 @@ class APITestCasePackage(TestCase):
                                     [
                                         (
                                             "url",
-                                            f"http://testserver/api/packages/{self.package_maven_jackson_databind_2_13_1.id}",
+                                            f"http://testserver/api/packages/{self.pkg_2_13_1.id}",
                                         ),
                                         (
                                             "purl",
@@ -594,7 +550,7 @@ class APITestCasePackage(TestCase):
                                         ("is_vulnerable", True),
                                         (
                                             "affected_by_vulnerabilities",
-                                            [{"vulnerability": "VCID-2nyb-8rwu-aaag"}],
+                                            [{"vulnerability": "VCID-vul1-vul1-vul1"}],
                                         ),
                                         (
                                             "resource_url",
@@ -605,17 +561,19 @@ class APITestCasePackage(TestCase):
                             ],
                         ),
                         ("aliases", ["CVE-2021-46877", "GHSA-3x8x-79m2-3w2w"]),
-                        ("resource_url", "http://testserver/vulnerabilities/VCID-ftmk-wbwx-aaar"),
+                        ("resource_url", "http://testserver/vulnerabilities/VCID-vul3-vul3-vul3"),
                     ]
                 )
             ],
             "resource_url": "http://testserver/packages/pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1",
         }
 
-        assert response == expected_response
+        assert json.dumps(response, indent=2) == json.dumps(expected_response, indent=2)
 
-    def test_is_vulnerable_attribute(self):
-        self.assertTrue(self.package_maven_jackson_databind_2_13_1.is_vulnerable)
+    def test_is_vulnerable_attribute_only_exists_on_queryset(self):
+        assert not hasattr(self.pkg_2_13_1, "is_vulnerable")
+        pkgs = Package.objects.filter(pk=self.pkg_2_13_1.pk).with_is_vulnerable()
+        assert all(hasattr(p, "is_vulnerable") for p in pkgs)
 
     def test_api_status(self):
         response = self.csrf_client.get("/api/packages/", format="json")
@@ -713,7 +671,7 @@ class BulkSearchAPIPackage(TestCase):
         self.auth = f"Token {self.user.auth_token.key}"
         self.csrf_client = APIClient(enforce_csrf_checks=True)
         self.csrf_client.credentials(HTTP_AUTHORIZATION=self.auth)
-        packages = [
+        packages = self.packages = [
             "pkg:nginx/nginx@0.6.18",
             "pkg:nginx/nginx@1.20.0",
             "pkg:nginx/nginx@1.21.0",
@@ -728,24 +686,18 @@ class BulkSearchAPIPackage(TestCase):
             "pkg:nginx/nginx@1.0.7",
             "pkg:nginx/nginx@1.0.15",
         ]
-        self.packages = packages
-        for package in packages:
-            purl = PackageURL.from_string(package)
-            attrs = {k: v for k, v in purl.to_dict().items() if v}
-            Package.objects.create(**attrs)
+        self.pkgs = [Package.objects.from_purl(p) for p in packages]
 
         vulnerable_packages = [
             "pkg:nginx/nginx@1.0.15?foo=bar",
             "pkg:nginx/nginx@1.0.15?foo=baz",
         ]
 
-        vuln = Vulnerability.objects.create(summary="test")
+        vulnerability = Vulnerability.objects.create(summary="test")
 
-        for package in vulnerable_packages:
-            purl = PackageURL.from_string(package)
-            attrs = {k: v for k, v in purl.to_dict().items() if v}
-            pkg = Package.objects.create(**attrs)
-            PackageRelatedVulnerability.objects.create(package=pkg, vulnerability=vuln)
+        for purl in vulnerable_packages:
+            package = Package.objects.from_purl(purl)
+            set_as_affected_by(package, vulnerability)
 
     def test_bulk_api_response(self):
         request_body = {

--- a/vulnerabilities/tests/test_throttling.py
+++ b/vulnerabilities/tests/test_throttling.py
@@ -48,8 +48,7 @@ class ThrottleApiTests(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         # A anonymous user can only access /packages endpoint 10 times a day
-        for i in range(0, 10):
-            print(i)
+        for _i in range(0, 10):
             response = self.csrf_client_anon.get("/api/packages")
             self.assertEqual(response.status_code, 200)
 

--- a/vulnerabilities/utils.py
+++ b/vulnerabilities/utils.py
@@ -23,6 +23,7 @@ from http import HTTPStatus
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 from unittest.mock import MagicMock
 from urllib.parse import urljoin
 from uuid import uuid4
@@ -563,7 +564,7 @@ def get_advisory_url(file, base_path, url):
     return advisory_url
 
 
-def purl_to_dict(purl: PackageURL, with_empty: bool = True):
+def purl_to_dict(purl: Union[PackageURL, str], with_empty: bool = True):
     """
     Return a dict of purl components suitable for use in a queryset.
     We need to have specific empty values for using in querysets because of our peculiar model structure.
@@ -585,10 +586,9 @@ def purl_to_dict(purl: PackageURL, with_empty: bool = True):
     return mapping
 
 
-def normalize_purl(purl: str):
+def normalize_purl(purl: Union[PackageURL, str]):
     """
-    Return a normalized purl object from a purl
-    string or purl object.
+    Return a normalized purl object from a purl string or purl object.
     """
     if isinstance(purl, PackageURL):
         purl = str(purl)

--- a/vulnerablecode/settings.py
+++ b/vulnerablecode/settings.py
@@ -289,7 +289,10 @@ if not VULNERABLECODEIO_REQUIRE_AUTHENTICATION:
 if DEBUG_TOOLBAR:
     INSTALLED_APPS += ("debug_toolbar",)
 
-    MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)
+    MIDDLEWARE += (
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+        "pyinstrument.middleware.ProfilerMiddleware",
+    )
 
     DEBUG_TOOLBAR_PANELS = (
         "debug_toolbar.panels.history.HistoryPanel",


### PR DESCRIPTION
This PR tries to improve the API lookup calls.

One hotspot is the the `Package.is_vulnerable` property that runs an exists() on a queryset
in a repeated manner.

To avoid this, the approach is to annotate the Package queryset(s) with an `is_vulnerable`
attribute.

The results with a single API call to http://127.0.0.1:8001/api/packages/63 are like this
using pyinstrument and django-toolbar on a laptop:

**Before**
* pyinstrument:
```
Absolute time
Duration: 1.46 seconds
Samples: 1376
CPU time: 1.3 seconds
```
* django-toolbar:
```
Time
Resource 	Value
User CPU time 	3992.892 msec
System CPU time 	69.885 msec
Total CPU time 	4062.777 msec
Elapsed time 	4162.812 msec
Context switches 	13364 voluntary, 52 involuntary

SQL
224.49 ms (1329 queries including 1327 similar and 1299 duplicates ) 
```

The pyinstrument hotspot are calls to:
```
Package.is_vulnerable
vulnerabilities/models.py:647
```

**After**:

* pyinstrument:
```
Absolute time
Duration: 0.288 seconds
Samples: 276
CPU time: 0.263 seconds
```

* django-toolbar:

```
Time
Resource 	Value
User CPU time 	395.396 msec
System CPU time 	20.186 msec
Total CPU time 	415.582 msec
Elapsed time 	439.888 msec
Context switches 	2588 voluntary, 17 involuntary

SQL
83.03 ms (99 queries including 96 similar and 68 duplicates ) 
```


Or an improvement looking like this:

| tool           | old       | new      | improvement 
|------          |--------   |----      |---
| pyinstrument   | 1.46 s    | 0.288 s  | x 5.06
| toolbar        | 4.16 s    | 0.439 s  | x 9.47


```


Reference:https://github.com/nexB/vulnerablecode/issues/1538
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
