### PR TITLE
Improve display of the Severity table of the Essentials screen

### DIFF
--- a/vulnerabilities/templates/vulnerability_details.html
+++ b/vulnerabilities/templates/vulnerability_details.html
@@ -68,7 +68,7 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                 <li data-tab="epss">
                     <a>
                         <span>
-                            EPSS
+                            EPSS ({{ epss_severities|length }})
                         </span>
                     </a>
                 </li>
@@ -501,13 +501,15 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                         </tr>
                     {% endfor %}
             </div>
-
-        
+            
             <div class="tab-div content" data-content="epss">
-                {% if epss_data %}
+            
+            {% if epss_severities %}
                     <div class="has-text-weight-bold tab-nested-div ml-1 mb-1 mt-1">
                         Exploit Prediction Scoring System (EPSS)
                     </div>
+
+                    {% with first=epss_severities.0 %}
                     <table class="table vcio-table width-100-pct mt-2">
                         <tbody>
                             <tr>
@@ -517,7 +519,7 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                                           Percentile
                                     </span>
                                 </td>
-                                <td class="two-col-right">{{ epss_data.percentile }}</td>
+                                <td class="two-col-right">{{ first.scoring_elements }}</td>
                             </tr>
                             <tr>
                                 <td class="two-col-left">
@@ -526,9 +528,8 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                                           EPSS Score
                                     </span>
                                 </td>
-                                <td class="two-col-right">{{ epss_data.score }}</td>
+                                <td class="two-col-right">{{ first.value }}</td>
                             </tr>
-                            {% if epss_data.published_at %}
                             <tr>
                                 <td class="two-col-left">
                                     <span class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
@@ -536,61 +537,90 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                                           Published At
                                     </span>
                                 </td>
-                                <td class="two-col-right">{{ epss_data.published_at }}</td>
+                                <td class="two-col-right">{{ first.published_at }}</td>
                             </tr>
-                            {% endif %}
                         </tbody>
                     </table>
-                {% else %}
-                    <p>No EPSS data available for this vulnerability.</p>
-                {% endif %}
-            </div>
+                    {% endwith %}
 
-        <div class="tab-div content" data-content="history">
-            <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
-                <thead>
+                    <div class="has-text-weight-bold tab-nested-div ml-1 mb-1 mt-1">
+                        EPSS History
+                    </div>
+
+                    <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth gray-header-border">
+                        <tr>
+                            <th style="width: 100px;"> Score </th>
+                            <th style="width: 100px;"> Percentile </th>
+                            <th> Published At </th>
+                            <th> Found at </th>
+                        </tr>
+                        {% for epss_severity in epss_severities %}
+                            <tr>
+                                <td class="wrap-strings">{{ epss_severity.value }}</td>
+                                <td class="wrap-strings">{{ epss_severity.scoring_elements }}</td>
+                                <td class="wrap-strings">{{ epss_severity.published_at }}</td>
+                                <td class="wrap-strings">
+                                    <a href="{{ epss_severity.url }}" target="_blank">
+                                        {{ epss_severity.url }}
+                                        <i class="fa fa-external-link fa_link_custom"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+            {% else %}
                     <tr>
-                        <th>
-                            <span
-                                class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
-                                data-tooltip="The date that the vulnerability was imported (collected) or improved.">
-                                Date </span>
-                        </th>
-                        <th>
-                            <span
-                                class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
-                                data-tooltip="The process that created or updated the vulnerability."> Actor </span>
-                        </th>
-                        <th> <span
-                                class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
-                                data-tooltip="Imported or Improved"> Action </span> </th>
-                        <th> <span
-                                class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
-                                data-tooltip="The public service that published the advisory or related information."> Source </span> </th>
-                        <th> <span
-                                class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
-                                data-tooltip="The version of VulnerableCode that performed the action. ">
-                                VulnerableCode Version
-                            </span> </th>
+                        <td colspan="2">
+                            No EPSS data available for this vulnerability.
+                        </td>
                     </tr>
-                </thead>
-                {% for log in history %}
-                <tr>
-                    <td class="is-break-word wrap-strings">{{ log.get_iso_time }}</td>
-                    <td class="is-break-word wrap-strings">{{ log.actor_name }}</td>
-                    <td class="is-break-word wrap-strings">{{ log.get_action_type_label }}</td>
-                    <td class="is-break-word wrap-strings"> <a href="{{ log.source_url }}" target="_blank">{{log.source_url }}</a></td>
-                    <td class="is-break-word wrap-strings"> {{ log.software_version }} </td>
-                </tr>
-                {% empty %}
-                <tr>
-                    <td colspan="5">
-                        There are no relevant records.
-                    </td>
-                </tr>
-                {% endfor %}
-            </table>
+            {% endif %}
         </div>
+            <div class="tab-div content" data-content="history">
+                <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
+                    <thead>
+                        <tr>
+                            <th>
+                                <span
+                                    class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                    data-tooltip="The date that the vulnerability was imported (collected) or improved.">
+                                    Date </span>
+                            </th>
+                            <th>
+                                <span
+                                    class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                    data-tooltip="The process that created or updated the vulnerability."> Actor </span>
+                            </th>
+                            <th> <span
+                                    class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                    data-tooltip="Imported or Improved"> Action </span> </th>
+                            <th> <span
+                                    class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                    data-tooltip="The public service that published the advisory or related information."> Source </span> </th>
+                            <th> <span
+                                    class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                    data-tooltip="The version of VulnerableCode that performed the action. ">
+                                    VulnerableCode Version
+                                </span> </th>
+                        </tr>
+                    </thead>
+                    {% for log in history %}
+                    <tr>
+                        <td class="is-break-word wrap-strings">{{ log.get_iso_time }}</td>
+                        <td class="is-break-word wrap-strings">{{ log.actor_name }}</td>
+                        <td class="is-break-word wrap-strings">{{ log.get_action_type_label }}</td>
+                        <td class="is-break-word wrap-strings"> <a href="{{ log.source_url }}" target="_blank">{{log.source_url }}</a></td>
+                        <td class="is-break-word wrap-strings"> {{ log.software_version }} </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="5">
+                            There are no relevant records.
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+            </div>
         </div>
     </div>
 </section>

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -7,6 +7,7 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 import logging
+from datetime import datetime
 
 from cvss.exceptions import CVSS2MalformedError
 from cvss.exceptions import CVSS3MalformedError
@@ -305,12 +306,19 @@ class VulnerabilityDetails(DetailView):
             if weakness_object.weakness
         ]
 
-        valid_severities = self.object.severities.exclude(scoring_system=EPSS.identifier).filter(
-            scoring_elements__isnull=False, scoring_system__in=SCORING_SYSTEMS.keys()
-        )
+        all_severities = list(self.object.severities.all().order_by("-published_at"))
+
+        valid_severities = [
+            s
+            for s in all_severities
+            if s.scoring_system != EPSS.identifier
+            and s.scoring_elements is not None
+            and s.scoring_system in SCORING_SYSTEMS
+        ]
+
+        epss_severities = [s for s in all_severities if s.scoring_system == EPSS.identifier]
 
         severity_vectors = []
-
         for severity in valid_severities:
             try:
                 vector_values_system = SCORING_SYSTEMS[severity.scoring_system]
@@ -328,30 +336,18 @@ class VulnerabilityDetails(DetailView):
             ):
                 logging.error(f"CVSSMalformedError for {severity.scoring_elements}")
 
-        epss_severity = vulnerability.severities.filter(scoring_system="epss").latest(
-            "published_at"
-        )
-
-        epss_data = None
-        if epss_severity:
-            epss_data = {
-                "percentile": epss_severity.scoring_elements,
-                "score": epss_severity.value,
-                "published_at": epss_severity.published_at,
-            }
-
         context.update(
             {
                 "vulnerability": vulnerability,
                 "vulnerability_search_form": VulnerabilitySearchForm(self.request.GET),
-                "severities": list(vulnerability.severities.all()),
+                "severities": list(self.object.severities.exclude(scoring_system=EPSS.identifier)),
                 "severity_vectors": severity_vectors,
+                "epss_severities": epss_severities,
                 "references": list(vulnerability.references.all()),
                 "aliases": list(vulnerability.aliases.all()),
                 "weaknesses": weaknesses_present_in_db,
                 "status": vulnerability.get_status_label,
                 "history": vulnerability.history,
-                "epss_data": epss_data,
             }
         )
         return context


### PR DESCRIPTION
issue: #1975
issue: #1732

<img width="1872" height="552" alt="image" src="https://github.com/user-attachments/assets/bcac42c7-1fef-4868-b419-107c9a442cb8" />

<img width="1874" height="148" alt="Screenshot from 2025-08-17 21-40-58" src="https://github.com/user-attachments/assets/8f316bfa-f693-469b-8774-32eee689aa25" />
