### PR TITLE
Cleans the version, as univers was rejecting the version with ':'

### DIFF
--- a/vulnerabilities/importers/gentoo.py
+++ b/vulnerabilities/importers/gentoo.py
@@ -103,15 +103,33 @@ class GentooImporter(Importer):
             purl = PackageURL(type="ebuild", name=pkg_name, namespace=pkg_ns)
             safe_versions, affected_versions = GentooImporter.get_safe_and_affected_versions(pkg)
 
+            # for version in safe_versions:
+            #     constraints.append(
+            #         VersionConstraint(version=GentooVersion(version), comparator="=").invert()
+            #     )
+
+            # for version in affected_versions:
+            #     constraints.append(
+            #         VersionConstraint(version=GentooVersion(version), comparator="=")
+            #     )
+
+            def clean_ver(v):
+                # removes ":something" which univers rejects
+                return v.split(":", 1)[0]
+            
             for version in safe_versions:
-                constraints.append(
-                    VersionConstraint(version=GentooVersion(version), comparator="=").invert()
-                )
+                try:
+                    v_obj = GentooVersion(version)
+                except Exception:
+                    v_obj = GentooVersion(clean_ver(version))
+                constraints.append(VersionConstraint(version=v_obj, comparator="=").invert())
 
             for version in affected_versions:
-                constraints.append(
-                    VersionConstraint(version=GentooVersion(version), comparator="=")
-                )
+                try:
+                    v_obj = GentooVersion(version)
+                except Exception:
+                    v_obj = GentooVersion(clean_ver(version))
+                constraints.append(VersionConstraint(version=v_obj, comparator="="))
 
             if not constraints:
                 continue


### PR DESCRIPTION
univers was rejecting versions containing ":"
so, I added some code to clean it, 1. First tries the original version 2. if error, cleans the version 3. tries again until working.

I hope this result is upto the mark, but do let me know if there is any discrepancies. Looking forward for your reviews, and sorry for being this late, my apologies.

* Fixes #2015 

Thank You!
