### PR TITLE
fix: replace bare except with explicit Exception in pipes/advisory.py

### DIFF
--- a/vulnerabilities/pipes/advisory.py
+++ b/vulnerabilities/pipes/advisory.py
@@ -456,7 +456,7 @@ def import_advisory(
                         f"and scoring_elements: {severity.scoring_elements!r}",
                         level=logging.DEBUG,
                     )
-            except:
+            except Exception:
                 if logger:
                     logger(
                         f"Failed to create VulnerabilitySeverity for: {severity} with error:\n{traceback_format_exc()}",

--- a/vulnerabilities/tests/test_bare_except_advisory.py
+++ b/vulnerabilities/tests/test_bare_except_advisory.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# VulnerableCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/aboutcode-org/vulnerablecode for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import ast
+import os
+
+
+def test_no_bare_except_in_advisory():
+    """Test that advisory.py does not contain bare except clauses."""
+    file_path = os.path.join(os.path.dirname(__file__), "..", "pipes", "advisory.py")
+    with open(file_path, "r") as f:
+        source = f.read()
+
+    tree = ast.parse(source)
+
+    bare_excepts = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler):
+            if node.type is None:
+                bare_excepts.append(node.lineno)
+
+    assert len(bare_excepts) == 0, f"Found bare except clauses at lines: {bare_excepts}"


### PR DESCRIPTION
fixes #2074

#### Proposed Fix
Replace bare `except:` with explicit `except Exception:`:
```
except Exception:
    if logger:
        logger(
            f"Failed to create VulnerabilitySeverity for: {severity} with error:\n{traceback_format_exc()}",
            level=logging.ERROR,
        )
```
#### Detection Method
Found using `ruff check . --select=E722` which reported 6 bare except violations in the codebase.
