### PR TITLE
Fix dead ScanCode Toolkit documentation link

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -73,7 +73,8 @@ overlooked. We value any suggestions to improve
 
 .. tip::
     Our documentation is treated like code. Make sure to check our
-    `writing guidelines <https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_doc.html>`_
+    `writing guidelines <https://scancode-toolkit.readthedocs.io/en/stable/contribute/
+>`_
     to help guide new users.
 
 Other Ways


### PR DESCRIPTION
Problem:
The ScanCode Toolkit contribution documentation link referenced in
VulnerableCode was returning a 404 and causing documentation build warnings.

Solution:
- Updated the dead link to point to the current ScanCode Toolkit
  contribution documentation.

Testing:
Documentation-only change.

Fixes: ScanCode-Toolkit [issue (#4645)](https://github.com/aboutcode-org/scancode-toolkit/issues/4645)


