### PR TITLE
Fix incorrect exception handling in insert_advisory_v2 (#2081)

### DIFF
--- a/vulnerabilities/pipes/advisory.py
+++ b/vulnerabilities/pipes/advisory.py
@@ -331,7 +331,7 @@ def insert_advisory_v2(
             if values:
                 getattr(advisory_obj, field_name).add(*values)
 
-    except Advisory.MultipleObjectsReturned:
+    except AdvisoryV2.MultipleObjectsReturned:
         logger.error(
             f"Multiple Advisories returned: unique_content_id: {content_id}, url: {advisory.url}, advisory: {advisory!r}"
         )


### PR DESCRIPTION
Problem

insert_advisory_v2 uses AdvisoryV2.objects.get_or_create(...), but the except block incorrectly catches Advisory.MultipleObjectsReturned.
When duplicate AdvisoryV2 records exist, Django raises AdvisoryV2.MultipleObjectsReturned, which was not being caught, causing the exception to propagate and break the pipeline.

Solution

Updated the exception handling to catch the correct exception:

Replaced Advisory.MultipleObjectsReturned

With AdvisoryV2.MultipleObjectsReturned

This ensures duplicate AdvisoryV2 records are handled correctly and prevents unexpected crashes during advisory ingestion.

Related Issue

Fixes: Incorrect try except in insert_advisory_v2 #2081
https://github.com/aboutcode-org/vulnerablecode/issues/2081