### PR TITLE
Fix incorrect default starting year in NVD importer

### DIFF
--- a/vulnerabilities/pipelines/v2_importers/nvd_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/nvd_importer.py
@@ -111,7 +111,7 @@ def fetch(url, logger=None):
     return json.loads(data)
 
 
-def fetch_cve_data_1_1(starting_year=2025, logger=None):
+def fetch_cve_data_1_1(starting_year=2002, logger=None):
     """
     Yield tuples of (year, lists of CVE mappings) from the NVD, one for each
     year since ``starting_year`` defaulting to 2002.


### PR DESCRIPTION
Problem

The function fetch_cve_data_1_1 in vulnerabilities/pipelines/v2_importers/nvd_importer.py uses starting_year=2025 as the default value.
However, NVD JSON CVE feeds are available starting from 2002, not 2025.
Because of this incorrect default, older CVE data (2002–2024) is skipped when the importer runs without explicitly passing a starting year.

Solution

Updated the default value of starting_year from 2025 to 2002 so the importer correctly fetches all available NVD CVE data by default, matching the documented behavior and NVD feed availability.

Changes Made

Changed fetch_cve_data_1_1(starting_year=2025) → fetch_cve_data_1_1(starting_year=2002)

No other logic or behavior was modified.

Issue Link

Fixes: Incorrect starting year #2079
https://github.com/aboutcode-org/vulnerablecode/issues/2079