### PR TITLE
Add V2 Importer for Tuxcare advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ toml==0.10.2
 tomli==2.0.1
 traitlets==5.1.1
 typing_extensions==4.1.1
-univers==30.12.0
+git+https://github.com/aboutcode-org/univers.git@5e28f2cd0fbee81a2b1268e88916a52a208bb672#egg=univers
 urllib3==1.26.19
 wcwidth==0.2.5
 websocket-client==0.59.0

--- a/vulnerabilities/importers/__init__.py
+++ b/vulnerabilities/importers/__init__.py
@@ -78,11 +78,11 @@ from vulnerabilities.pipelines.v2_importers import pysec_importer as pysec_impor
 from vulnerabilities.pipelines.v2_importers import redhat_importer as redhat_importer_v2
 from vulnerabilities.pipelines.v2_importers import retiredotnet_importer as retiredotnet_importer_v2
 from vulnerabilities.pipelines.v2_importers import ruby_importer as ruby_importer_v2
+from vulnerabilities.pipelines.v2_importers import tuxcare_importer as tuxcare_importer_v2
 from vulnerabilities.pipelines.v2_importers import suse_score_importer as suse_score_importer_v2
 from vulnerabilities.pipelines.v2_importers import ubuntu_osv_importer as ubuntu_osv_importer_v2
 from vulnerabilities.pipelines.v2_importers import vulnrichment_importer as vulnrichment_importer_v2
 from vulnerabilities.pipelines.v2_importers import xen_importer as xen_importer_v2
-from vulnerabilities.pipelines.v2_importers import tuxcare_importer as tuxcare_importer_v2
 from vulnerabilities.utils import create_registry
 
 IMPORTERS_REGISTRY = create_registry(

--- a/vulnerabilities/importers/__init__.py
+++ b/vulnerabilities/importers/__init__.py
@@ -78,8 +78,8 @@ from vulnerabilities.pipelines.v2_importers import pysec_importer as pysec_impor
 from vulnerabilities.pipelines.v2_importers import redhat_importer as redhat_importer_v2
 from vulnerabilities.pipelines.v2_importers import retiredotnet_importer as retiredotnet_importer_v2
 from vulnerabilities.pipelines.v2_importers import ruby_importer as ruby_importer_v2
-from vulnerabilities.pipelines.v2_importers import tuxcare_importer as tuxcare_importer_v2
 from vulnerabilities.pipelines.v2_importers import suse_score_importer as suse_score_importer_v2
+from vulnerabilities.pipelines.v2_importers import tuxcare_importer as tuxcare_importer_v2
 from vulnerabilities.pipelines.v2_importers import ubuntu_osv_importer as ubuntu_osv_importer_v2
 from vulnerabilities.pipelines.v2_importers import vulnrichment_importer as vulnrichment_importer_v2
 from vulnerabilities.pipelines.v2_importers import xen_importer as xen_importer_v2

--- a/vulnerabilities/importers/__init__.py
+++ b/vulnerabilities/importers/__init__.py
@@ -82,6 +82,7 @@ from vulnerabilities.pipelines.v2_importers import suse_score_importer as suse_s
 from vulnerabilities.pipelines.v2_importers import ubuntu_osv_importer as ubuntu_osv_importer_v2
 from vulnerabilities.pipelines.v2_importers import vulnrichment_importer as vulnrichment_importer_v2
 from vulnerabilities.pipelines.v2_importers import xen_importer as xen_importer_v2
+from vulnerabilities.pipelines.v2_importers import tuxcare_importer as tuxcare_importer_v2
 from vulnerabilities.utils import create_registry
 
 IMPORTERS_REGISTRY = create_registry(
@@ -113,6 +114,7 @@ IMPORTERS_REGISTRY = create_registry(
         nginx_importer_v2.NginxImporterPipeline,
         debian_importer_v2.DebianImporterPipeline,
         mattermost_importer_v2.MattermostImporterPipeline,
+        tuxcare_importer_v2.TuxCareImporterPipeline,
         apache_tomcat_v2.ApacheTomcatImporterPipeline,
         suse_score_importer_v2.SUSESeverityScoreImporterPipeline,
         retiredotnet_importer_v2.RetireDotnetImporterPipeline,

--- a/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
@@ -14,7 +14,10 @@ from typing import Iterable
 from dateutil.parser import parse
 from packageurl import PackageURL
 from pytz import UTC
+from univers.version_range import AlpineLinuxVersionRange
+from univers.version_range import DebianVersionRange
 from univers.version_range import GenericVersionRange
+from univers.version_range import RpmVersionRange
 
 from vulnerabilities.importer import AdvisoryData
 from vulnerabilities.importer import AffectedPackageV2
@@ -24,6 +27,18 @@ from vulnerabilities.severity_systems import GENERIC
 from vulnerabilities.utils import fetch_response
 
 logger = logging.getLogger(__name__)
+
+# See https://docs.tuxcare.com/els-for-os/#cve-status-definition
+NON_AFFECTED_STATUSES = ["Not Vulnerable"]
+AFFECTED_STATUSES = ["Ignored", "Needs Triage", "In Testing", "In Progress", "In Rollout"]
+FIXED_STATUSES = ["Released", "Already Fixed"]
+
+VERSION_RANGE_BY_PURL_TYPE = {
+    "rpm": RpmVersionRange,
+    "deb": DebianVersionRange,
+    "apk": AlpineLinuxVersionRange,
+    "generic": GenericVersionRange,
+}
 
 
 class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
@@ -43,9 +58,54 @@ class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
         self.log(f"Fetching `{url}`")
         response = fetch_response(url)
         self.response = response.json() if response else []
+        self._grouped = self._group_records_by_cve()
+
+    def _group_records_by_cve(self) -> dict:
+        grouped = {}
+        skipped_invalid = 0
+        skipped_non_affected = 0
+
+        for record in self.response:
+            cve_id = record.get("cve", "").strip()
+            if not cve_id or not cve_id.startswith("CVE-"):
+                logger.warning(f"Skipping invalid CVE ID: {cve_id}")
+                skipped_invalid += 1
+                continue
+
+            os_name = record.get("os_name", "").strip()
+            project_name = record.get("project_name", "").strip()
+            version = record.get("version", "").strip()
+            status = record.get("status", "").strip()
+
+            if not all([os_name, project_name, version, status]):
+                logger.warning(f"Skipping {cve_id}: missing required fields")
+                skipped_invalid += 1
+                continue
+
+            # Skip records with non-affected statuses
+            if status in NON_AFFECTED_STATUSES:
+                skipped_non_affected += 1
+                continue
+
+            if status not in AFFECTED_STATUSES and status not in FIXED_STATUSES:
+                logger.warning(f"Skipping {cve_id}: unrecognized status '{status}'")
+                skipped_invalid += 1
+                continue
+
+            if cve_id not in grouped:
+                grouped[cve_id] = []
+            grouped[cve_id].append(record)
+
+        total_skipped = skipped_invalid + skipped_non_affected
+        self.log(
+            f"Grouped {len(self.response):,d} records into {len(grouped):,d} unique CVEs "
+            f"(skipped {total_skipped:,d}: {skipped_invalid:,d} invalid, "
+            f"{skipped_non_affected:,d} non-affected)"
+        )
+        return grouped
 
     def advisories_count(self) -> int:
-        return len(self.response)
+        return len(self._grouped)
 
     def _create_purl(self, project_name: str, os_name: str) -> PackageURL:
         normalized_os = os_name.lower().replace(" ", "-")
@@ -64,9 +124,6 @@ class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
             "tuxcare": ("generic", "tuxcare"),
         }
 
-        pkg_type = "generic"
-        namespace = "tuxcare"
-
         for keyword, (ptype, pns) in os_mapping.items():
             if keyword in os_lower:
                 pkg_type = ptype
@@ -75,105 +132,90 @@ class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
         else:
             return None
 
-        qualifiers = {}
-        if normalized_os:
-            qualifiers["distro"] = normalized_os
+        qualifiers = {"distro": normalized_os}
 
         return PackageURL(
             type=pkg_type, namespace=namespace, name=project_name, qualifiers=qualifiers
         )
 
     def collect_advisories(self) -> Iterable[AdvisoryData]:
-        for record in self.response:
-            cve_id = record.get("cve", "").strip()
-            if not cve_id or not cve_id.startswith("CVE-"):
-                logger.warning(f"Skipping record with invalid CVE ID: {cve_id}")
-                continue
+        grouped_by_cve = self._grouped
 
-            os_name = record.get("os_name", "").strip()
-            project_name = record.get("project_name", "").strip()
-            version = record.get("version", "").strip()
-            score = record.get("score", "").strip()
-            severity = record.get("severity", "").strip()
-            status = record.get("status", "").strip()
-            last_updated = record.get("last_updated", "").strip()
-
-            if not all([os_name, project_name, version, status]):
-                logger.warning(f"Skipping {cve_id} - missing required fields")
-                continue
-
-            # See https://docs.tuxcare.com/els-for-os/#cve-status-definition
-            non_affected_statuses = ["Not Vulnerable"]
-            affected_statuses = [
-                "Ignored",
-                "Needs Triage",
-                "In Testing",
-                "In Progress",
-                "In Rollout",
-            ]
-            fixed_statuses = ["Released", "Already Fixed"]
-
-            # Skip CVEs that are not vulnerable
-            if status in non_affected_statuses:
-                continue
-
-            if status not in affected_statuses and status not in fixed_statuses:
-                logger.warning(f"Skipping {cve_id} - unknown status: {status}")
-                continue
-
-            normalized_os = os_name.lower().replace(" ", "-")
-            advisory_id = f"{cve_id}-{normalized_os}-{project_name.lower()}-{version}"
-
-            purl = self._create_purl(project_name, os_name)
-            if not purl:
-                logger.warning(f"Skipping {cve_id} - unexpected OS type: '{os_name}'")
-                continue
-
-            try:
-                version_range = GenericVersionRange.from_versions([version])
-            except ValueError as e:
-                logger.warning(f"Failed to parse version {version} for {cve_id}: {e}")
-                continue
-
-            affected_version_range = None
-            fixed_version_range = None
-
-            if status in affected_statuses:
-                affected_version_range = version_range
-            elif status in fixed_statuses:
-                fixed_version_range = version_range
-
-            affected_packages = [
-                AffectedPackageV2(
-                    package=purl,
-                    affected_version_range=affected_version_range,
-                    fixed_version_range=fixed_version_range,
-                )
-            ]
-
+        for cve_id, records in grouped_by_cve.items():
+            affected_packages = []
             severities = []
-            if severity and score:
-                severities.append(
-                    VulnerabilitySeverity(
-                        system=GENERIC,
-                        value=score,
-                        scoring_elements=severity,
+            date_published = None
+            all_records = []
+            severity_added = False
+
+            for record in records:
+                os_name = record.get("os_name", "").strip()
+                project_name = record.get("project_name", "").strip()
+                version = record.get("version", "").strip()
+                score = record.get("score", "").strip()
+                severity = record.get("severity", "").strip()
+                status = record.get("status", "").strip()
+                last_updated = record.get("last_updated", "").strip()
+
+                purl = self._create_purl(project_name, os_name)
+                if not purl:
+                    logger.warning(
+                        f"Skipping package {project_name} on {os_name} for {cve_id} - unexpected OS type"
+                    )
+                    continue
+
+                version_range_class = VERSION_RANGE_BY_PURL_TYPE.get(purl.type, GenericVersionRange)
+                try:
+                    version_range = version_range_class.from_versions([version])
+                except ValueError as e:
+                    logger.warning(f"Failed to parse version {version} for {cve_id}: {e}")
+                    continue
+
+                affected_version_range = None
+                fixed_version_range = None
+
+                if status in AFFECTED_STATUSES:
+                    affected_version_range = version_range
+                elif status in FIXED_STATUSES:
+                    fixed_version_range = version_range
+
+                affected_packages.append(
+                    AffectedPackageV2(
+                        package=purl,
+                        affected_version_range=affected_version_range,
+                        fixed_version_range=fixed_version_range,
                     )
                 )
 
-            date_published = None
-            if last_updated:
-                try:
-                    date_published = parse(last_updated).replace(tzinfo=UTC)
-                except ValueError as e:
-                    logger.warning(f"Failed to parse date {last_updated} for {cve_id}: {e}")
+                if severity and score and not severity_added:
+                    severities.append(
+                        VulnerabilitySeverity(
+                            system=GENERIC,
+                            value=score,
+                            scoring_elements=severity,
+                        )
+                    )
+                    severity_added = True
+
+                if last_updated:
+                    try:
+                        current_date = parse(last_updated).replace(tzinfo=UTC)
+                        if date_published is None or current_date > date_published:
+                            date_published = current_date
+                    except ValueError as e:
+                        logger.warning(f"Failed to parse date {last_updated} for {cve_id}: {e}")
+
+                all_records.append(record)
+
+            if not affected_packages:
+                logger.warning(f"Skipping {cve_id} - no valid affected packages")
+                continue
 
             yield AdvisoryData(
-                advisory_id=advisory_id,
-                aliases=[cve_id],
+                advisory_id=cve_id,
                 affected_packages=affected_packages,
                 severities=severities,
                 date_published=date_published,
                 url=f"https://cve.tuxcare.com/els/cve/{cve_id}",
-                original_advisory_text=json.dumps(record, indent=2, ensure_ascii=False),
+                original_advisory_text=json.dumps(all_records, indent=2, ensure_ascii=False),
             )

--- a/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
@@ -1,0 +1,114 @@
+import json
+import logging
+from typing import Iterable
+
+from dateutil import parser as date_parser
+from django.utils import timezone
+from packageurl import PackageURL
+from univers.version_range import GenericVersionRange
+
+from vulnerabilities.importer import AdvisoryData
+from vulnerabilities.importer import AffectedPackageV2
+from vulnerabilities.importer import ReferenceV2
+from vulnerabilities.importer import VulnerabilitySeverity
+from vulnerabilities.pipelines import VulnerableCodeBaseImporterPipelineV2
+from vulnerabilities.severity_systems import GENERIC
+from vulnerabilities.utils import fetch_response
+
+logger = logging.getLogger(__name__)
+
+
+class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
+    pipeline_id = "tuxcare_importer_v2"
+    spdx_license_expression = "Apache-2.0"
+    license_url = "https://tuxcare.com/legal"
+    url = "https://cve.tuxcare.com/els/download-json?orderBy=updated-desc"
+
+    @classmethod
+    def steps(cls):
+        return (cls.collect_and_store_advisories,)
+
+    def advisories_count(self) -> int:
+        response = fetch_response(self.url)
+        data = response.json() if response else []
+        return len(data)
+
+    def collect_advisories(self) -> Iterable[AdvisoryData]:
+        response = fetch_response(self.url)
+        if not response:
+            return
+
+        data = response.json()
+        if not data:
+            return
+
+        for record in data:
+            cve_id = record.get("cve", "").strip()
+            if not cve_id or not cve_id.startswith("CVE-"):
+                continue
+
+            os_name = record.get("os_name", "").strip()
+            project_name = record.get("project_name", "").strip()
+            version = record.get("version", "").strip()
+            score = record.get("score", "").strip()
+            severity = record.get("severity", "").strip()
+            status = record.get("status", "").strip()
+            last_updated = record.get("last_updated", "").strip()
+
+            safe_os = os_name.replace(" ", "_") if os_name else "unknown"
+            advisory_id = f"TUXCARE-{cve_id}-{safe_os}-{project_name}"
+
+            summary = f"TuxCare advisory for {cve_id}"
+            if project_name:
+                summary += f" in {project_name}"
+            if os_name:
+                summary += f" on {os_name}"
+
+            affected_packages = []
+            if project_name:
+                purl = PackageURL(type="generic", name=project_name)
+                
+                affected_version_range = None
+                if version:
+                    try:
+                        affected_version_range = GenericVersionRange.from_versions([version])
+                    except Exception:
+                        pass
+
+                affected_packages.append(
+                    AffectedPackageV2(
+                        package=purl,
+                        affected_version_range=affected_version_range,
+                    )
+                )
+
+            severities = []
+            if severity and score:
+                severities.append(
+                    VulnerabilitySeverity(
+                        system=GENERIC,
+                        value=f"{severity} ({score})",
+                        scoring_elements=f"score={score},severity={severity}",
+                    )
+                )
+
+            date_published = None
+            if last_updated:
+                try:
+                    date_published = date_parser.parse(last_updated)
+                    if timezone.is_naive(date_published):
+                        date_published = timezone.make_aware(date_published, timezone=timezone.utc)
+                except Exception:
+                    pass
+
+            yield AdvisoryData(
+                advisory_id=advisory_id,
+                aliases=[cve_id],
+                summary=summary,
+                affected_packages=affected_packages,
+                references_v2=[ReferenceV2(url="https://cve.tuxcare.com/")],
+                severities=severities,
+                date_published=date_published,
+                url="https://cve.tuxcare.com/",
+                original_advisory_text=json.dumps(record, indent=2, ensure_ascii=False),
+            )

--- a/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Iterable, Mapping
+from typing import Iterable
+from typing import Mapping
 
 from dateutil.parser import parse
 from packageurl import PackageURL

--- a/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/tuxcare_importer.py
@@ -33,6 +33,8 @@ class TuxCareImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
     spdx_license_expression = "Apache-2.0"
     license_url = "https://tuxcare.com/legal"
 
+    precedence = 100
+
     @classmethod
     def steps(cls):
         return (

--- a/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# VulnerableCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/aboutcode-org/vulnerablecode for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import json
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from vulnerabilities.pipelines.v2_importers.tuxcare_importer import TuxCareImporterPipeline
+from vulnerabilities.tests import util_tests
+
+TEST_DATA = Path(__file__).parent.parent.parent / "test_data" / "tuxcare"
+
+
+class TestTuxCareImporterPipeline(TestCase):
+    @patch("vulnerabilities.pipelines.v2_importers.tuxcare_importer.fetch_response")
+    def test_collect_advisories(self, mock_fetch):
+        """Test collecting and parsing advisories from test data"""
+        sample_path = TEST_DATA / "data.json"
+        sample_data = json.loads(sample_path.read_text(encoding="utf-8"))
+
+        mock_fetch.return_value = Mock(json=lambda: sample_data)
+
+        pipeline = TuxCareImporterPipeline()
+        advisories = [data.to_dict() for data in list(pipeline.collect_advisories())]
+
+        expected_file = TEST_DATA / "expected.json"
+        util_tests.check_results_against_json(advisories, expected_file)
+
+    @patch("vulnerabilities.pipelines.v2_importers.tuxcare_importer.fetch_response")
+    def test_advisories_count(self, mock_fetch):
+        """Test counting advisories"""
+        sample_path = TEST_DATA / "data.json"
+        sample_data = json.loads(sample_path.read_text(encoding="utf-8"))
+
+        mock_fetch.return_value = Mock(json=lambda: sample_data)
+
+        pipeline = TuxCareImporterPipeline()
+        count = pipeline.advisories_count()
+
+        assert count == 5

--- a/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
@@ -35,4 +35,4 @@ class TestTuxCareImporterPipeline(TestCase):
         expected_file = TEST_DATA / "expected.json"
         util_tests.check_results_against_json(advisories, expected_file)
 
-        assert pipeline.advisories_count() == 5
+        assert pipeline.advisories_count() == 13

--- a/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
@@ -35,4 +35,4 @@ class TestTuxCareImporterPipeline(TestCase):
         expected_file = TEST_DATA / "expected.json"
         util_tests.check_results_against_json(advisories, expected_file)
 
-        assert pipeline.advisories_count() == 13
+        assert len(advisories) == 14

--- a/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_tuxcare_importer_v2.py
@@ -22,27 +22,17 @@ TEST_DATA = Path(__file__).parent.parent.parent / "test_data" / "tuxcare"
 class TestTuxCareImporterPipeline(TestCase):
     @patch("vulnerabilities.pipelines.v2_importers.tuxcare_importer.fetch_response")
     def test_collect_advisories(self, mock_fetch):
-        """Test collecting and parsing advisories from test data"""
         sample_path = TEST_DATA / "data.json"
         sample_data = json.loads(sample_path.read_text(encoding="utf-8"))
 
         mock_fetch.return_value = Mock(json=lambda: sample_data)
 
         pipeline = TuxCareImporterPipeline()
+        pipeline.fetch()
+
         advisories = [data.to_dict() for data in list(pipeline.collect_advisories())]
 
         expected_file = TEST_DATA / "expected.json"
         util_tests.check_results_against_json(advisories, expected_file)
 
-    @patch("vulnerabilities.pipelines.v2_importers.tuxcare_importer.fetch_response")
-    def test_advisories_count(self, mock_fetch):
-        """Test counting advisories"""
-        sample_path = TEST_DATA / "data.json"
-        sample_data = json.loads(sample_path.read_text(encoding="utf-8"))
-
-        mock_fetch.return_value = Mock(json=lambda: sample_data)
-
-        pipeline = TuxCareImporterPipeline()
-        count = pipeline.advisories_count()
-
-        assert count == 5
+        assert pipeline.advisories_count() == 5

--- a/vulnerabilities/tests/test_data/tuxcare/data.json
+++ b/vulnerabilities/tests/test_data/tuxcare/data.json
@@ -20,6 +20,46 @@
     "last_updated": "2025-12-23 10:08:35.944749"
   },
   {
+    "cve": "CVE-2023-52922",
+    "os_name": "CentOS 8.5 ELS",
+    "project_name": "kernel",
+    "version": "4.18.0",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Released",
+    "last_updated": "2025-05-21 01:43:28.677045"
+  },
+  {
+    "cve": "CVE-2023-52922",
+    "os_name": "AlmaLinux 9.2 ESU",
+    "project_name": "squid",
+    "version": "5.5",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Not Vulnerable",
+    "last_updated": "2025-08-28 00:52:25.579518"
+  },
+  {
+    "cve": "CVE-2023-52922",
+    "os_name": "RHEL 7 ELS",
+    "project_name": "squid",
+    "version": "3.5.20",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Not Vulnerable",
+    "last_updated": "2025-11-27 10:32:13.088814"
+  },
+  {
+    "cve": "CVE-2023-52922",
+    "os_name": "CentOS Stream 8 ELS",
+    "project_name": "squid",
+    "version": "4.15",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Ignored",
+    "last_updated": "2025-08-28 22:56:12.357818"
+  },
+  {
     "cve": "CVE-2023-48161",
     "os_name": "RHEL 7 ELS",
     "project_name": "java-11-openjdk",
@@ -128,5 +168,35 @@
     "severity": "MEDIUM",
     "status": "In Rollout",
     "last_updated": "2025-12-20 04:34:51.112485"
+  },
+  {
+    "cve": "CVE-2022-50268",
+    "os_name": "Ubuntu 16.04 ELS",
+    "project_name": "linux",
+    "version": "4.4.0",
+    "score": "5.5",
+    "severity": "MEDIUM",
+    "status": "Needs Triage",
+    "last_updated": "2025-12-23 07:31:24.920518"
+  },
+  {
+    "cve": "CVE-2020-1472",
+    "os_name": "Debian 10 ELS",
+    "project_name": "samba",
+    "version": "4.9.5",
+    "score": "0.0",
+    "severity": "",
+    "status": "In Testing",
+    "last_updated": "2025-12-22 16:58:13.189255"
+  },
+  {
+    "cve": "CVE-2025-6297",
+    "os_name": "Alpine Linux 3.18 ELS",
+    "project_name": "dpkg",
+    "version": "1.21.21",
+    "score": "0.0",
+    "severity": "",
+    "status": "Released",
+    "last_updated": "2025-12-19 05:00:40.874276"
   }
 ]

--- a/vulnerabilities/tests/test_data/tuxcare/data.json
+++ b/vulnerabilities/tests/test_data/tuxcare/data.json
@@ -1,0 +1,52 @@
+[
+  {
+    "cve": "CVE-2023-52922",
+    "os_name": "CloudLinux 7 ELS",
+    "project_name": "squid",
+    "version": "3.5.20",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "In Testing",
+    "last_updated": "2025-12-23 10:08:36.423446"
+  },
+  {
+    "cve": "CVE-2023-52922",
+    "os_name": "Oracle Linux 7 ELS",
+    "project_name": "squid",
+    "version": "3.5.20",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "In Testing",
+    "last_updated": "2025-12-23 10:08:35.944749"
+  },
+  {
+    "cve": "CVE-2023-48161",
+    "os_name": "RHEL 7 ELS",
+    "project_name": "java-11-openjdk",
+    "version": "11.0.23",
+    "score": "7.1",
+    "severity": "HIGH",
+    "status": "In Progress",
+    "last_updated": "2025-12-23 08:55:12.096092"
+  },
+  {
+    "cve": "CVE-2024-21147",
+    "os_name": "RHEL 7 ELS",
+    "project_name": "java-11-openjdk",
+    "version": "11.0.23",
+    "score": "7.4",
+    "severity": "HIGH",
+    "status": "In Progress",
+    "last_updated": "2025-12-23 08:55:07.139188"
+  },
+  {
+    "cve": "CVE-2025-21587",
+    "os_name": "RHEL 7 ELS",
+    "project_name": "java-11-openjdk",
+    "version": "11.0.23",
+    "score": "7.4",
+    "severity": "HIGH",
+    "status": "In Progress",
+    "last_updated": "2025-12-23 08:55:06.706873"
+  }
+]

--- a/vulnerabilities/tests/test_data/tuxcare/data.json
+++ b/vulnerabilities/tests/test_data/tuxcare/data.json
@@ -48,5 +48,85 @@
     "severity": "HIGH",
     "status": "In Progress",
     "last_updated": "2025-12-23 08:55:06.706873"
+  },
+  {
+    "cve": "CVE-2024-39502",
+    "os_name": "Unknown OS",
+    "project_name": "kernel",
+    "version": "2.6.32",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Needs Triage",
+    "last_updated": "2025-09-20 06:03:30.551756"
+  },
+  {
+    "cve": "CVE-2024-40927",
+    "os_name": "Unknown OS",
+    "project_name": "kernel",
+    "version": "2.6.32",
+    "score": "7.8",
+    "severity": "HIGH",
+    "status": "Needs Triage",
+    "last_updated": "2025-09-20 06:03:26.132106"
+  },
+  {
+    "cve": "CVE-2025-4517",
+    "os_name": "CentOS 8.4 ELS",
+    "project_name": "python2",
+    "version": "2.7.18",
+    "score": "7.6",
+    "severity": "HIGH",
+    "status": "Not Vulnerable",
+    "last_updated": "2025-12-22 16:43:49.287021"
+  },
+  {
+    "cve": "CVE-2025-43392",
+    "os_name": "TuxCare 9.6 ESU",
+    "project_name": "webkit2gtk3",
+    "version": "2.50.1",
+    "score": "6.5",
+    "severity": "MEDIUM",
+    "status": "In Testing",
+    "last_updated": "2025-12-20 04:26:48.737089"
+  },
+  {
+    "cve": "CVE-2023-50868",
+    "os_name": "CloudLinux 7 ELS",
+    "project_name": "dhcp",
+    "version": "4.2.5",
+    "score": "7.5",
+    "severity": "HIGH",
+    "status": "Already Fixed",
+    "last_updated": "2025-12-23 01:56:28.627699"
+  },
+  {
+    "cve": "CVE-2021-33193",
+    "os_name": "Unknown OS",
+    "project_name": "httpd",
+    "version": "2.2.15",
+    "score": "7.5",
+    "severity": "HIGH",
+    "status": "Ignored",
+    "last_updated": "2025-09-19 21:21:01.425783"
+  },
+  {
+    "cve": "CVE-2025-50093",
+    "os_name": "AlmaLinux 9.2 ESU",
+    "project_name": "mysql",
+    "version": "8.0.32",
+    "score": "4.9",
+    "severity": "MEDIUM",
+    "status": "Released",
+    "last_updated": "2025-12-22 17:11:15.409148"
+  },
+  {
+    "cve": "CVE-2025-64505",
+    "os_name": "CentOS 7 ELS",
+    "project_name": "libpng",
+    "version": "1.5.13",
+    "score": "4.4",
+    "severity": "MEDIUM",
+    "status": "In Rollout",
+    "last_updated": "2025-12-20 04:34:51.112485"
   }
 ]

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -1,9 +1,7 @@
 [
   {
-    "advisory_id": "CVE-2023-52922-cloudlinux-7-els-squid-3.5.20",
-    "aliases": [
-      "CVE-2023-52922"
-    ],
+    "advisory_id": "CVE-2023-52922",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -15,7 +13,49 @@
           "qualifiers": "distro=cloudlinux-7-els",
           "subpath": ""
         },
-        "affected_version_range": "vers:generic/3.5.20",
+        "affected_version_range": "vers:rpm/3.5.20",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      },
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "oracle",
+          "name": "squid",
+          "version": "",
+          "qualifiers": "distro=oracle-linux-7-els",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:rpm/3.5.20",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      },
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "centos",
+          "name": "kernel",
+          "version": "",
+          "qualifiers": "distro=centos-8.5-els",
+          "subpath": ""
+        },
+        "affected_version_range": null,
+        "fixed_version_range": "vers:rpm/4.18.0",
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      },
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "centos",
+          "name": "squid",
+          "version": "",
+          "qualifiers": "distro=centos-stream-8-els",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:rpm/4.15",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
@@ -35,45 +75,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
   },
   {
-    "advisory_id": "CVE-2023-52922-oracle-linux-7-els-squid-3.5.20",
-    "aliases": [
-      "CVE-2023-52922"
-    ],
-    "summary": "",
-    "affected_packages": [
-      {
-        "package": {
-          "type": "rpm",
-          "namespace": "oracle",
-          "name": "squid",
-          "version": "",
-          "qualifiers": "distro=oracle-linux-7-els",
-          "subpath": ""
-        },
-        "affected_version_range": "vers:generic/3.5.20",
-        "fixed_version_range": null,
-        "introduced_by_commit_patches": [],
-        "fixed_by_commit_patches": []
-      }
-    ],
-    "references_v2": [],
-    "patches": [],
-    "severities": [
-      {
-        "system": "generic_textual",
-        "value": "7.8",
-        "scoring_elements": "HIGH"
-      }
-    ],
-    "date_published": "2025-12-23T10:08:35.944749+00:00",
-    "weaknesses": [],
-    "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
-  },
-  {
-    "advisory_id": "CVE-2023-48161-rhel-7-els-java-11-openjdk-11.0.23",
-    "aliases": [
-      "CVE-2023-48161"
-    ],
+    "advisory_id": "CVE-2023-48161",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -85,7 +88,7 @@
           "qualifiers": "distro=rhel-7-els",
           "subpath": ""
         },
-        "affected_version_range": "vers:generic/11.0.23",
+        "affected_version_range": "vers:rpm/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
@@ -105,10 +108,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-48161"
   },
   {
-    "advisory_id": "CVE-2024-21147-rhel-7-els-java-11-openjdk-11.0.23",
-    "aliases": [
-      "CVE-2024-21147"
-    ],
+    "advisory_id": "CVE-2024-21147",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -120,7 +121,7 @@
           "qualifiers": "distro=rhel-7-els",
           "subpath": ""
         },
-        "affected_version_range": "vers:generic/11.0.23",
+        "affected_version_range": "vers:rpm/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
@@ -140,10 +141,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2024-21147"
   },
   {
-    "advisory_id": "CVE-2025-21587-rhel-7-els-java-11-openjdk-11.0.23",
-    "aliases": [
-      "CVE-2025-21587"
-    ],
+    "advisory_id": "CVE-2025-21587",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -155,7 +154,7 @@
           "qualifiers": "distro=rhel-7-els",
           "subpath": ""
         },
-        "affected_version_range": "vers:generic/11.0.23",
+        "affected_version_range": "vers:rpm/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
@@ -175,10 +174,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2025-21587"
   },
   {
-    "advisory_id": "CVE-2024-39502-unknown-os-kernel-2.6.32",
-    "aliases": [
-      "CVE-2024-39502"
-    ],
+    "advisory_id": "CVE-2024-39502",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -210,10 +207,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2024-39502"
   },
   {
-    "advisory_id": "CVE-2024-40927-unknown-os-kernel-2.6.32",
-    "aliases": [
-      "CVE-2024-40927"
-    ],
+    "advisory_id": "CVE-2024-40927",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -245,10 +240,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2024-40927"
   },
   {
-    "advisory_id": "CVE-2025-43392-tuxcare-9.6-esu-webkit2gtk3-2.50.1",
-    "aliases": [
-      "CVE-2025-43392"
-    ],
+    "advisory_id": "CVE-2025-43392",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -280,10 +273,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2025-43392"
   },
   {
-    "advisory_id": "CVE-2023-50868-cloudlinux-7-els-dhcp-4.2.5",
-    "aliases": [
-      "CVE-2023-50868"
-    ],
+    "advisory_id": "CVE-2023-50868",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -296,7 +287,7 @@
           "subpath": ""
         },
         "affected_version_range": null,
-        "fixed_version_range": "vers:generic/4.2.5",
+        "fixed_version_range": "vers:rpm/4.2.5",
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
       }
@@ -315,10 +306,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-50868"
   },
   {
-    "advisory_id": "CVE-2021-33193-unknown-os-httpd-2.2.15",
-    "aliases": [
-      "CVE-2021-33193"
-    ],
+    "advisory_id": "CVE-2021-33193",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -350,10 +339,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2021-33193"
   },
   {
-    "advisory_id": "CVE-2025-50093-almalinux-9.2-esu-mysql-8.0.32",
-    "aliases": [
-      "CVE-2025-50093"
-    ],
+    "advisory_id": "CVE-2025-50093",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -366,7 +353,7 @@
           "subpath": ""
         },
         "affected_version_range": null,
-        "fixed_version_range": "vers:generic/8.0.32",
+        "fixed_version_range": "vers:rpm/8.0.32",
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
       }
@@ -385,10 +372,8 @@
     "url": "https://cve.tuxcare.com/els/cve/CVE-2025-50093"
   },
   {
-    "advisory_id": "CVE-2025-64505-centos-7-els-libpng-1.5.13",
-    "aliases": [
-      "CVE-2025-64505"
-    ],
+    "advisory_id": "CVE-2025-64505",
+    "aliases": [],
     "summary": "",
     "affected_packages": [
       {
@@ -400,7 +385,7 @@
           "qualifiers": "distro=centos-7-els",
           "subpath": ""
         },
-        "affected_version_range": "vers:generic/1.5.13",
+        "affected_version_range": "vers:rpm/1.5.13",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
         "fixed_by_commit_patches": []
@@ -418,5 +403,92 @@
     "date_published": "2025-12-20T04:34:51.112485+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2025-64505"
+  },
+  {
+    "advisory_id": "CVE-2022-50268",
+    "aliases": [],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "deb",
+          "namespace": "ubuntu",
+          "name": "linux",
+          "version": "",
+          "qualifiers": "distro=ubuntu-16.04-els",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:deb/4.4.0",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "5.5",
+        "scoring_elements": "MEDIUM"
+      }
+    ],
+    "date_published": "2025-12-23T07:31:24.920518+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2022-50268"
+  },
+  {
+    "advisory_id": "CVE-2020-1472",
+    "aliases": [],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "deb",
+          "namespace": "debian",
+          "name": "samba",
+          "version": "",
+          "qualifiers": "distro=debian-10-els",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:deb/4.9.5",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [],
+    "date_published": "2025-12-22T16:58:13.189255+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2020-1472"
+  },
+  {
+    "advisory_id": "CVE-2025-6297",
+    "aliases": [],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "apk",
+          "namespace": "alpine",
+          "name": "dpkg",
+          "version": "",
+          "qualifiers": "distro=alpine-linux-3.18-els",
+          "subpath": ""
+        },
+        "affected_version_range": null,
+        "fixed_version_range": "vers:alpine/1.21.21",
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [],
+    "date_published": "2025-12-19T05:00:40.874276+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2025-6297"
   }
 ]

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -1,7 +1,7 @@
 [
   {
-    "advisory_id": "TUXCARE-CVE-2023-52922-CloudLinux_7_ELS-squid",
-    "aliases": ["CVE-2023-52922"],
+    "advisory_id": "CVE-2023-52922",
+    "aliases": [],
     "summary": "TuxCare advisory for CVE-2023-52922 in squid on CloudLinux 7 ELS",
     "affected_packages": [
       {
@@ -12,16 +12,16 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "HIGH (7.8)", "scoring_elements": "score=7.8,severity=HIGH"}],
+    "severities": [{"system": "generic_textual", "value": "7.8", "scoring_elements": "HIGH"}],
     "date_published": "2025-12-23T10:08:36.423446+00:00",
     "weaknesses": [],
-    "url": "https://cve.tuxcare.com/"
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
   },
   {
-    "advisory_id": "TUXCARE-CVE-2023-52922-Oracle_Linux_7_ELS-squid",
-    "aliases": ["CVE-2023-52922"],
+    "advisory_id": "CVE-2023-52922",
+    "aliases": [],
     "summary": "TuxCare advisory for CVE-2023-52922 in squid on Oracle Linux 7 ELS",
     "affected_packages": [
       {
@@ -32,16 +32,16 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "HIGH (7.8)", "scoring_elements": "score=7.8,severity=HIGH"}],
+    "severities": [{"system": "generic_textual", "value": "7.8", "scoring_elements": "HIGH"}],
     "date_published": "2025-12-23T10:08:35.944749+00:00",
     "weaknesses": [],
-    "url": "https://cve.tuxcare.com/"
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
   },
   {
-    "advisory_id": "TUXCARE-CVE-2023-48161-RHEL_7_ELS-java-11-openjdk",
-    "aliases": ["CVE-2023-48161"],
+    "advisory_id": "CVE-2023-48161",
+    "aliases": [],
     "summary": "TuxCare advisory for CVE-2023-48161 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
@@ -52,16 +52,16 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "HIGH (7.1)", "scoring_elements": "score=7.1,severity=HIGH"}],
+    "severities": [{"system": "generic_textual", "value": "7.1", "scoring_elements": "HIGH"}],
     "date_published": "2025-12-23T08:55:12.096092+00:00",
     "weaknesses": [],
-    "url": "https://cve.tuxcare.com/"
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2023-48161"
   },
   {
-    "advisory_id": "TUXCARE-CVE-2024-21147-RHEL_7_ELS-java-11-openjdk",
-    "aliases": ["CVE-2024-21147"],
+    "advisory_id": "CVE-2024-21147",
+    "aliases": [],
     "summary": "TuxCare advisory for CVE-2024-21147 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
@@ -72,16 +72,16 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "HIGH (7.4)", "scoring_elements": "score=7.4,severity=HIGH"}],
+    "severities": [{"system": "generic_textual", "value": "7.4", "scoring_elements": "HIGH"}],
     "date_published": "2025-12-23T08:55:07.139188+00:00",
     "weaknesses": [],
-    "url": "https://cve.tuxcare.com/"
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2024-21147"
   },
   {
-    "advisory_id": "TUXCARE-CVE-2025-21587-RHEL_7_ELS-java-11-openjdk",
-    "aliases": ["CVE-2025-21587"],
+    "advisory_id": "CVE-2025-21587",
+    "aliases": [],
     "summary": "TuxCare advisory for CVE-2025-21587 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
@@ -92,11 +92,11 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "HIGH (7.4)", "scoring_elements": "score=7.4,severity=HIGH"}],
+    "severities": [{"system": "generic_textual", "value": "7.4", "scoring_elements": "HIGH"}],
     "date_published": "2025-12-23T08:55:06.706873+00:00",
     "weaknesses": [],
-    "url": "https://cve.tuxcare.com/"
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2025-21587"
   }
 ]

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -1,0 +1,102 @@
+[
+  {
+    "advisory_id": "TUXCARE-CVE-2023-52922-CloudLinux_7_ELS-squid",
+    "aliases": ["CVE-2023-52922"],
+    "summary": "TuxCare advisory for CVE-2023-52922 in squid on CloudLinux 7 ELS",
+    "affected_packages": [
+      {
+        "package": {"type": "generic", "namespace": "", "name": "squid", "version": "", "qualifiers": "", "subpath": ""},
+        "affected_version_range": "vers:generic/3.5.20",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "patches": [],
+    "severities": [{"system": "generic_textual", "value": "HIGH (7.8)", "scoring_elements": "score=7.8,severity=HIGH"}],
+    "date_published": "2025-12-23T10:08:36.423446+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/"
+  },
+  {
+    "advisory_id": "TUXCARE-CVE-2023-52922-Oracle_Linux_7_ELS-squid",
+    "aliases": ["CVE-2023-52922"],
+    "summary": "TuxCare advisory for CVE-2023-52922 in squid on Oracle Linux 7 ELS",
+    "affected_packages": [
+      {
+        "package": {"type": "generic", "namespace": "", "name": "squid", "version": "", "qualifiers": "", "subpath": ""},
+        "affected_version_range": "vers:generic/3.5.20",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "patches": [],
+    "severities": [{"system": "generic_textual", "value": "HIGH (7.8)", "scoring_elements": "score=7.8,severity=HIGH"}],
+    "date_published": "2025-12-23T10:08:35.944749+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/"
+  },
+  {
+    "advisory_id": "TUXCARE-CVE-2023-48161-RHEL_7_ELS-java-11-openjdk",
+    "aliases": ["CVE-2023-48161"],
+    "summary": "TuxCare advisory for CVE-2023-48161 in java-11-openjdk on RHEL 7 ELS",
+    "affected_packages": [
+      {
+        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "affected_version_range": "vers:generic/11.0.23",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "patches": [],
+    "severities": [{"system": "generic_textual", "value": "HIGH (7.1)", "scoring_elements": "score=7.1,severity=HIGH"}],
+    "date_published": "2025-12-23T08:55:12.096092+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/"
+  },
+  {
+    "advisory_id": "TUXCARE-CVE-2024-21147-RHEL_7_ELS-java-11-openjdk",
+    "aliases": ["CVE-2024-21147"],
+    "summary": "TuxCare advisory for CVE-2024-21147 in java-11-openjdk on RHEL 7 ELS",
+    "affected_packages": [
+      {
+        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "affected_version_range": "vers:generic/11.0.23",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "patches": [],
+    "severities": [{"system": "generic_textual", "value": "HIGH (7.4)", "scoring_elements": "score=7.4,severity=HIGH"}],
+    "date_published": "2025-12-23T08:55:07.139188+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/"
+  },
+  {
+    "advisory_id": "TUXCARE-CVE-2025-21587-RHEL_7_ELS-java-11-openjdk",
+    "aliases": ["CVE-2025-21587"],
+    "summary": "TuxCare advisory for CVE-2025-21587 in java-11-openjdk on RHEL 7 ELS",
+    "affected_packages": [
+      {
+        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "affected_version_range": "vers:generic/11.0.23",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [{"reference_id": "", "reference_type": "", "url": "https://cve.tuxcare.com/"}],
+    "patches": [],
+    "severities": [{"system": "generic_textual", "value": "HIGH (7.4)", "scoring_elements": "score=7.4,severity=HIGH"}],
+    "date_published": "2025-12-23T08:55:06.706873+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/"
+  }
+]

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -61,7 +61,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -94,7 +94,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -127,7 +127,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -160,7 +160,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -193,7 +193,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -226,7 +226,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -259,7 +259,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -292,7 +292,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -325,7 +325,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -358,7 +358,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -391,7 +391,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -424,7 +424,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [
       {
@@ -457,7 +457,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [],
     "date_published": "2025-12-22T16:58:13.189255+00:00",
@@ -484,7 +484,7 @@
         "fixed_by_commit_patches": []
       }
     ],
-    "references_v2": [],
+    "references": [],
     "patches": [],
     "severities": [],
     "date_published": "2025-12-19T05:00:40.874276+00:00",

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -2,10 +2,10 @@
   {
     "advisory_id": "CVE-2023-52922",
     "aliases": [],
-    "summary": "TuxCare advisory for CVE-2023-52922 in squid on CloudLinux 7 ELS",
+    "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "rpm", "namespace": "cloudlinux", "name": "squid", "version": "", "qualifiers": "os=CloudLinux%207%20ELS", "subpath": ""},
+        "package": {"type": "generic", "namespace": "tuxcare", "name": "squid", "version": "", "qualifiers": "distro=CloudLinux%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -22,10 +22,10 @@
   {
     "advisory_id": "CVE-2023-52922",
     "aliases": [],
-    "summary": "TuxCare advisory for CVE-2023-52922 in squid on Oracle Linux 7 ELS",
+    "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "rpm", "namespace": "oracle", "name": "squid", "version": "", "qualifiers": "os=Oracle%20Linux%207%20ELS", "subpath": ""},
+        "package": {"type": "generic", "namespace": "tuxcare", "name": "squid", "version": "", "qualifiers": "distro=Oracle%20Linux%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -42,10 +42,10 @@
   {
     "advisory_id": "CVE-2023-48161",
     "aliases": [],
-    "summary": "TuxCare advisory for CVE-2023-48161 in java-11-openjdk on RHEL 7 ELS",
+    "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
+        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -62,10 +62,10 @@
   {
     "advisory_id": "CVE-2024-21147",
     "aliases": [],
-    "summary": "TuxCare advisory for CVE-2024-21147 in java-11-openjdk on RHEL 7 ELS",
+    "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
+        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -82,10 +82,10 @@
   {
     "advisory_id": "CVE-2025-21587",
     "aliases": [],
-    "summary": "TuxCare advisory for CVE-2025-21587 in java-11-openjdk on RHEL 7 ELS",
+    "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
+        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -5,7 +5,7 @@
     "summary": "TuxCare advisory for CVE-2023-52922 in squid on CloudLinux 7 ELS",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "", "name": "squid", "version": "", "qualifiers": "", "subpath": ""},
+        "package": {"type": "rpm", "namespace": "cloudlinux", "name": "squid", "version": "", "qualifiers": "os=CloudLinux%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -25,7 +25,7 @@
     "summary": "TuxCare advisory for CVE-2023-52922 in squid on Oracle Linux 7 ELS",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "", "name": "squid", "version": "", "qualifiers": "", "subpath": ""},
+        "package": {"type": "rpm", "namespace": "oracle", "name": "squid", "version": "", "qualifiers": "os=Oracle%20Linux%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -45,7 +45,7 @@
     "summary": "TuxCare advisory for CVE-2023-48161 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -65,7 +65,7 @@
     "summary": "TuxCare advisory for CVE-2024-21147 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -85,7 +85,7 @@
     "summary": "TuxCare advisory for CVE-2025-21587 in java-11-openjdk on RHEL 7 ELS",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "", "name": "java-11-openjdk", "version": "", "qualifiers": "", "subpath": ""},
+        "package": {"type": "rpm", "namespace": "redhat", "name": "java-11-openjdk", "version": "", "qualifiers": "os=RHEL%207%20ELS", "subpath": ""},
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],

--- a/vulnerabilities/tests/test_data/tuxcare/expected.json
+++ b/vulnerabilities/tests/test_data/tuxcare/expected.json
@@ -1,11 +1,20 @@
 [
   {
-    "advisory_id": "CVE-2023-52922",
-    "aliases": [],
+    "advisory_id": "CVE-2023-52922-cloudlinux-7-els-squid-3.5.20",
+    "aliases": [
+      "CVE-2023-52922"
+    ],
     "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "tuxcare", "name": "squid", "version": "", "qualifiers": "distro=CloudLinux%207%20ELS", "subpath": ""},
+        "package": {
+          "type": "rpm",
+          "namespace": "cloudlinux",
+          "name": "squid",
+          "version": "",
+          "qualifiers": "distro=cloudlinux-7-els",
+          "subpath": ""
+        },
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -14,18 +23,33 @@
     ],
     "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "7.8", "scoring_elements": "HIGH"}],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.8",
+        "scoring_elements": "HIGH"
+      }
+    ],
     "date_published": "2025-12-23T10:08:36.423446+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
   },
   {
-    "advisory_id": "CVE-2023-52922",
-    "aliases": [],
+    "advisory_id": "CVE-2023-52922-oracle-linux-7-els-squid-3.5.20",
+    "aliases": [
+      "CVE-2023-52922"
+    ],
     "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "tuxcare", "name": "squid", "version": "", "qualifiers": "distro=Oracle%20Linux%207%20ELS", "subpath": ""},
+        "package": {
+          "type": "rpm",
+          "namespace": "oracle",
+          "name": "squid",
+          "version": "",
+          "qualifiers": "distro=oracle-linux-7-els",
+          "subpath": ""
+        },
         "affected_version_range": "vers:generic/3.5.20",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -34,18 +58,33 @@
     ],
     "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "7.8", "scoring_elements": "HIGH"}],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.8",
+        "scoring_elements": "HIGH"
+      }
+    ],
     "date_published": "2025-12-23T10:08:35.944749+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-52922"
   },
   {
-    "advisory_id": "CVE-2023-48161",
-    "aliases": [],
+    "advisory_id": "CVE-2023-48161-rhel-7-els-java-11-openjdk-11.0.23",
+    "aliases": [
+      "CVE-2023-48161"
+    ],
     "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
+        "package": {
+          "type": "rpm",
+          "namespace": "rhel",
+          "name": "java-11-openjdk",
+          "version": "",
+          "qualifiers": "distro=rhel-7-els",
+          "subpath": ""
+        },
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -54,18 +93,33 @@
     ],
     "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "7.1", "scoring_elements": "HIGH"}],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.1",
+        "scoring_elements": "HIGH"
+      }
+    ],
     "date_published": "2025-12-23T08:55:12.096092+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2023-48161"
   },
   {
-    "advisory_id": "CVE-2024-21147",
-    "aliases": [],
+    "advisory_id": "CVE-2024-21147-rhel-7-els-java-11-openjdk-11.0.23",
+    "aliases": [
+      "CVE-2024-21147"
+    ],
     "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
+        "package": {
+          "type": "rpm",
+          "namespace": "rhel",
+          "name": "java-11-openjdk",
+          "version": "",
+          "qualifiers": "distro=rhel-7-els",
+          "subpath": ""
+        },
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -74,18 +128,33 @@
     ],
     "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "7.4", "scoring_elements": "HIGH"}],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.4",
+        "scoring_elements": "HIGH"
+      }
+    ],
     "date_published": "2025-12-23T08:55:07.139188+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2024-21147"
   },
   {
-    "advisory_id": "CVE-2025-21587",
-    "aliases": [],
+    "advisory_id": "CVE-2025-21587-rhel-7-els-java-11-openjdk-11.0.23",
+    "aliases": [
+      "CVE-2025-21587"
+    ],
     "summary": "",
     "affected_packages": [
       {
-        "package": {"type": "generic", "namespace": "tuxcare", "name": "java-11-openjdk", "version": "", "qualifiers": "distro=RHEL%207%20ELS", "subpath": ""},
+        "package": {
+          "type": "rpm",
+          "namespace": "rhel",
+          "name": "java-11-openjdk",
+          "version": "",
+          "qualifiers": "distro=rhel-7-els",
+          "subpath": ""
+        },
         "affected_version_range": "vers:generic/11.0.23",
         "fixed_version_range": null,
         "introduced_by_commit_patches": [],
@@ -94,9 +163,260 @@
     ],
     "references_v2": [],
     "patches": [],
-    "severities": [{"system": "generic_textual", "value": "7.4", "scoring_elements": "HIGH"}],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.4",
+        "scoring_elements": "HIGH"
+      }
+    ],
     "date_published": "2025-12-23T08:55:06.706873+00:00",
     "weaknesses": [],
     "url": "https://cve.tuxcare.com/els/cve/CVE-2025-21587"
+  },
+  {
+    "advisory_id": "CVE-2024-39502-unknown-os-kernel-2.6.32",
+    "aliases": [
+      "CVE-2024-39502"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "generic",
+          "namespace": "tuxcare",
+          "name": "kernel",
+          "version": "",
+          "qualifiers": "distro=unknown-os",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:generic/2.6.32",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.8",
+        "scoring_elements": "HIGH"
+      }
+    ],
+    "date_published": "2025-09-20T06:03:30.551756+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2024-39502"
+  },
+  {
+    "advisory_id": "CVE-2024-40927-unknown-os-kernel-2.6.32",
+    "aliases": [
+      "CVE-2024-40927"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "generic",
+          "namespace": "tuxcare",
+          "name": "kernel",
+          "version": "",
+          "qualifiers": "distro=unknown-os",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:generic/2.6.32",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.8",
+        "scoring_elements": "HIGH"
+      }
+    ],
+    "date_published": "2025-09-20T06:03:26.132106+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2024-40927"
+  },
+  {
+    "advisory_id": "CVE-2025-43392-tuxcare-9.6-esu-webkit2gtk3-2.50.1",
+    "aliases": [
+      "CVE-2025-43392"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "generic",
+          "namespace": "tuxcare",
+          "name": "webkit2gtk3",
+          "version": "",
+          "qualifiers": "distro=tuxcare-9.6-esu",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:generic/2.50.1",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "6.5",
+        "scoring_elements": "MEDIUM"
+      }
+    ],
+    "date_published": "2025-12-20T04:26:48.737089+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2025-43392"
+  },
+  {
+    "advisory_id": "CVE-2023-50868-cloudlinux-7-els-dhcp-4.2.5",
+    "aliases": [
+      "CVE-2023-50868"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "cloudlinux",
+          "name": "dhcp",
+          "version": "",
+          "qualifiers": "distro=cloudlinux-7-els",
+          "subpath": ""
+        },
+        "affected_version_range": null,
+        "fixed_version_range": "vers:generic/4.2.5",
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.5",
+        "scoring_elements": "HIGH"
+      }
+    ],
+    "date_published": "2025-12-23T01:56:28.627699+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2023-50868"
+  },
+  {
+    "advisory_id": "CVE-2021-33193-unknown-os-httpd-2.2.15",
+    "aliases": [
+      "CVE-2021-33193"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "generic",
+          "namespace": "tuxcare",
+          "name": "httpd",
+          "version": "",
+          "qualifiers": "distro=unknown-os",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:generic/2.2.15",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "7.5",
+        "scoring_elements": "HIGH"
+      }
+    ],
+    "date_published": "2025-09-19T21:21:01.425783+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2021-33193"
+  },
+  {
+    "advisory_id": "CVE-2025-50093-almalinux-9.2-esu-mysql-8.0.32",
+    "aliases": [
+      "CVE-2025-50093"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "almalinux",
+          "name": "mysql",
+          "version": "",
+          "qualifiers": "distro=almalinux-9.2-esu",
+          "subpath": ""
+        },
+        "affected_version_range": null,
+        "fixed_version_range": "vers:generic/8.0.32",
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "4.9",
+        "scoring_elements": "MEDIUM"
+      }
+    ],
+    "date_published": "2025-12-22T17:11:15.409148+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2025-50093"
+  },
+  {
+    "advisory_id": "CVE-2025-64505-centos-7-els-libpng-1.5.13",
+    "aliases": [
+      "CVE-2025-64505"
+    ],
+    "summary": "",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "rpm",
+          "namespace": "centos",
+          "name": "libpng",
+          "version": "",
+          "qualifiers": "distro=centos-7-els",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:generic/1.5.13",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references_v2": [],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "4.4",
+        "scoring_elements": "MEDIUM"
+      }
+    ],
+    "date_published": "2025-12-20T04:34:51.112485+00:00",
+    "weaknesses": [],
+    "url": "https://cve.tuxcare.com/els/cve/CVE-2025-64505"
   }
 ]


### PR DESCRIPTION
Addresses Issue: 
- https://github.com/aboutcode-org/vulnerablecode/issues/2004

Data Source: https://cve.tuxcare.com/els/download-json?orderBy=updated-desc

Importer Log Excerpt:

```python
Importing data using tuxcare_importer_v2
INFO 2026-01-26 19:49:29.721368 UTC Pipeline [TuxCareImporterPipeline] starting
INFO 2026-01-26 19:49:29.721706 UTC Step [fetch] starting
INFO 2026-01-26 19:49:29.721766 UTC Fetching `https://cve.tuxcare.com/els/download-json?orderBy=updated-desc`
INFO 2026-01-26 19:51:10.961749 UTC Grouped 66,363 records into 9,649 unique CVEs (skipped 11,023: 0 invalid, 11,023 non-affected)
INFO 2026-01-26 19:51:10.963427 UTC Step [fetch] completed in 101 seconds (1.7 minutes)
INFO 2026-01-26 19:51:10.963586 UTC Step [collect_and_store_advisories] starting
INFO 2026-01-26 19:51:10.963635 UTC Collecting 9,649 advisories
INFO 2026-01-26 19:51:19.935667 UTC Progress: 10% (965/9649) ETA: 81 seconds (1.4 minutes)
INFO 2026-01-26 19:51:27.608222 UTC Progress: 20% (1930/9649) ETA: 67 seconds (1.1 minutes)
INFO 2026-01-26 19:51:36.572045 UTC Progress: 30% (2895/9649) ETA: 60 seconds
INFO 2026-01-26 19:51:45.463802 UTC Progress: 40% (3860/9649) ETA: 52 seconds
INFO 2026-01-26 19:51:54.916604 UTC Progress: 50% (4825/9649) ETA: 44 seconds
INFO 2026-01-26 19:52:02.836165 UTC Progress: 60% (5790/9649) ETA: 35 seconds
INFO 2026-01-26 19:52:11.500848 UTC Progress: 70% (6755/9649) ETA: 26 seconds
INFO 2026-01-26 19:52:20.017145 UTC Progress: 80% (7720/9649) ETA: 17 seconds
INFO 2026-01-26 19:52:28.159588 UTC Progress: 90% (8685/9649) ETA: 9 seconds
INFO 2026-01-26 19:52:35.721813 UTC Progress: 100% (9649/9649)
INFO 2026-01-26 19:52:35.729484 UTC Successfully collected 9,649 advisories
INFO 2026-01-26 19:52:35.729635 UTC Step [collect_and_store_advisories] completed in 85 seconds (1.4 minutes)
INFO 2026-01-26 19:52:35.729686 UTC Pipeline completed in 186 seconds (3.1 minutes)
```

