### PR TITLE
Fix spelling typos in docs, source, and tests (#2134)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -517,10 +517,10 @@ The summary of performance improvements include these fixes:
   that are needed in the UI
 - Do not recreate querysets from scratch but instead allow these to be chained
   for simpler and correct code.
-- Remove extra details from the vulnerability pacge: each package was further
+- Remove extra details from the vulnerability package: each package was further
   listing its related vulnerabilities creating an iceberg query.
 - Enable the django-debug-toolbar with a setting to easily profile queries on demand
-  by setting both VULNERABLECODE_DEBUG and VULNERABLECODE_DEBUG_TOOLBAR enviroment
+  by setting both VULNERABLECODE_DEBUG and VULNERABLECODE_DEBUG_TOOLBAR environment
   variables.
 
 

--- a/aboutcode/federated/README.rst
+++ b/aboutcode/federated/README.rst
@@ -28,7 +28,7 @@ repository names. A Data Cluster is akin to a table in a traditional database.
 3. **Data Repository**: A DataCluster contains of one or more Git Data Repository,
 each storing datafiles of the cluster data kind and a one PURL type, spreading
 the datafiles in multiple Data Directories. The name is data-kind +PURL-
-type+hashid. A Repository is similar to a shard or tablespace in a traditionale
+type+hashid. A Repository is similar to a shard or tablespace in a traditional
 database.
 
 4. **Data Directory**: In a Repository, a Data Directory contains the datafiles for

--- a/aboutcode/federated/__init__.py
+++ b/aboutcode/federated/__init__.py
@@ -336,7 +336,7 @@ Rebalancing and splitting a DataCluster repos
 
 We can rebalance a cluster, like when we first store the data in a cluster with
 a single Git repository for a given PURL type, and later split this repo to more
-repos, without loosing the ability to address datafiles directly just knowing a
+repos, without losing the ability to address datafiles directly just knowing a
 PURL and without having to rename all the files and directories.
 
 In this design, the directory names are stable and do not change as long as we
@@ -1511,7 +1511,7 @@ def compute_purl_hash(purl: Union[PackageURL, str], max_value: int = 1024) -> st
     - Convert the PURL to a core PURL with only type, namespace and name.
     - Compute a SHA256 hash on that core PURL string encoded to bytes as UTF-8.
     - Convert that hash value to an integer.
-    - Compute a modulo on that integer with the the max value.
+    - Compute a modulo on that integer with the max value.
       With default max_value of 1024, this yields an int between 0 and 1023.
     - Convert that integer to a 4-characters string left-padded with zero.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -82,7 +82,7 @@ to run on a different port than 8000.
 
    Serving VulnerableCode on a network could lead to security issues and there
    are several steps that may be needed to secure such a deployment.
-   Currently, this is not recommendend.
+   Currently, this is not recommended.
 
 Execute a Command
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/reference_importer_overview.rst
+++ b/docs/source/reference_importer_overview.rst
@@ -8,10 +8,10 @@ and for storing the scraped information in a structured fashion. The structured 
 importer then provides input to an improver (see :ref:`improver-overview`), which is responsible
 for creating a relational model for vulnerabilities, affected packages and fixed packages.
 
-All importer implementation-related code is defined in :file:`vulnerabilites/importer.py`.
+All importer implementation-related code is defined in :file:`vulnerabilities/importer.py`.
 
 In addition, the framework-related code for actually invoking and processing the importers is
-located in :file:`vulnerabilites/import_runner.py`.
+located in :file:`vulnerabilities/import_runner.py`.
 
 The importers, after scraping, provide ``AdvisoryData`` objects. These objects are then
 processed and inserted into the ``Advisory`` model.

--- a/docs/source/reference_improver_overview.rst
+++ b/docs/source/reference_improver_overview.rst
@@ -4,7 +4,7 @@ Improver Overview
 ===================
 
 Improvers improve upon already imported data. They are responsible for creating a relational
-model for vulnerabilites and packages.
+model for vulnerabilities and packages.
 
 An Improver is intended to contain data points about a vulnerability and the relevant discrete
 affected and fixed packages (in the form of `PackageURLs
@@ -17,7 +17,7 @@ relationship is stored in the database.
 There are two categories of improvers:
 
 - **Generic**: Improve upon some imported data irrespective of any importer. These improvers are
-  defined in :file:`vulnerabilites/improvers/`.
+  defined in :file:`vulnerabilities/improvers/`.
 - **Importer Specific**: Improve upon data imported by a specific importer. These are defined in the
   corresponding importer file itself.
 
@@ -30,5 +30,5 @@ answer, which could also be ``MAX_CONFIDENCE`` in certain cases.
 The possibilities with improvers are endless; they are not restricted to take one approach. Features
 like *Time Travel* and *finding fix commits* could be implemented as well.
 
-You can find more in-code documentation about improvers in :file:`vulnerabilites/improver.py` and
-the framework responsible for invoking these improvers in :file:`vulnerabilites/improve_runner.py`.
+You can find more in-code documentation about improvers in :file:`vulnerabilities/improver.py` and
+the framework responsible for invoking these improvers in :file:`vulnerabilities/improve_runner.py`.

--- a/docs/source/tutorial_add_importer_pipeline.rst
+++ b/docs/source/tutorial_add_importer_pipeline.rst
@@ -162,7 +162,7 @@ At this point, an example importer will look like this:
         pipeline_id = "example_importer"
 
         root_url = "https://example.org/path/to/advisories/"
-        license_url = "https://exmaple.org/license/"
+        license_url = "https://example.org/license/"
         spdx_license_expression = "CC-BY-4.0"
         importer_name = "Example Importer"
 

--- a/docs/source/tutorial_add_improver_pipeline.rst
+++ b/docs/source/tutorial_add_improver_pipeline.rst
@@ -115,7 +115,7 @@ At this point improver will look like this:
 
         pipeline_id = "flag_ghost_package_with_example_org"
 
-        license_url = "https://exmaple.org/license/"
+        license_url = "https://example.org/license/"
         spdx_license_expression = "CC-BY-4.0"
 
         @classmethod
@@ -152,7 +152,7 @@ methods.
 
         pipeline_id = "flag_ghost_package_with_example_org"
 
-        license_url = "https://exmaple.org/license/"
+        license_url = "https://example.org/license/"
         spdx_license_expression = "CC-BY-4.0"
 
         @classmethod

--- a/vulnerabilities/import_runner.py
+++ b/vulnerabilities/import_runner.py
@@ -284,7 +284,7 @@ def get_or_create_vulnerability_and_aliases(
     aliases: QuerySet, vulnerability_id=None, summary=None, advisory=None
 ):
     """
-    Get or create vulnerabilitiy and aliases such that all existing and new
+    Get or create vulnerability and aliases such that all existing and new
     aliases point to the same vulnerability
     """
     new_aliases, existing_vulns = get_vulns_for_aliases_and_get_new_aliases(aliases)

--- a/vulnerabilities/improve_runner.py
+++ b/vulnerabilities/improve_runner.py
@@ -194,7 +194,7 @@ def get_or_create_vulnerability_and_aliases(
     aliases: List[str], vulnerability_id=None, summary=None, advisory=None
 ):
     """
-    Get or create vulnerabilitiy and aliases such that all existing and new
+    Get or create vulnerability and aliases such that all existing and new
     aliases point to the same vulnerability
     """
     aliases = set(alias.strip() for alias in aliases if alias and alias.strip())

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -132,7 +132,7 @@ class VulnerabilityQuerySet(BaseQuerySet):
 
     def for_cve(self, cve):
         """
-        Return a queryset of Vulnerability that have the the NVD CVE ``cve`` as an alias.
+        Return a queryset of Vulnerability that have the NVD CVE ``cve`` as an alias.
         """
         return self.filter(vulnerabilityreference__reference_id__exact=cve)
 

--- a/vulnerabilities/pipelines/nvd_importer.py
+++ b/vulnerabilities/pipelines/nvd_importer.py
@@ -169,7 +169,7 @@ class CveItem:
         # In 99% of cases len(cve_item['cve']['description']['description_data']) == 1 , so
         # this usually returns  cve_item['cve']['description']['description_data'][0]['value']
         # In the remaining 1% cases this returns the longest summary.
-        # FIXME: we should retun the full description WITH the summry as the first line instead
+        # FIXME: we should return the full description WITH the summary as the first line instead
         summaries = []
         for desc in get_item(self.cve_item, "cve", "description", "description_data") or []:
             if desc.get("value"):

--- a/vulnerabilities/pipelines/v2_importers/nvd_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/nvd_importer.py
@@ -173,7 +173,7 @@ class CveItem:
         # In 99% of cases len(cve_item['cve']['description']['description_data']) == 1 , so
         # this usually returns  cve_item['cve']['description']['description_data'][0]['value']
         # In the remaining 1% cases this returns the longest summary.
-        # FIXME: we should retun the full description WITH the summry as the first line instead
+        # FIXME: we should return the full description WITH the summary as the first line instead
         summaries = []
         for desc in get_item(self.cve_item, "cve", "description", "description_data") or []:
             if desc.get("value"):

--- a/vulnerabilities/tests/pipelines/test_nginx_importer_pipeline.py
+++ b/vulnerabilities/tests/pipelines/test_nginx_importer_pipeline.py
@@ -196,7 +196,7 @@ class TestNginxImporterAndImprover(testcase.FileBasedTesting):
 
     @mock.patch("fetchcode.utils.github_response")
     def test_NginxBasicImprover_fetch_nginx_version_from_git_tags(self, mock_fetcher):
-        reponse_files = [
+        response_files = [
             "github-nginx-nginx-0.json",
             "github-nginx-nginx-1.json",
             "github-nginx-nginx-2.json",
@@ -205,7 +205,7 @@ class TestNginxImporterAndImprover(testcase.FileBasedTesting):
             "github-nginx-nginx-5.json",
         ]
         side_effects = []
-        for response_file in reponse_files:
+        for response_file in response_files:
             with open(self.get_test_loc(f"improver/{response_file}")) as f:
                 side_effects.append(json.load(f))
         mock_fetcher.side_effect = side_effects

--- a/vulnerabilities/utils.py
+++ b/vulnerabilities/utils.py
@@ -445,7 +445,7 @@ def clean_nginx_git_tag(tag):
     Return a cleaned ``version`` string from an nginx git tag.
 
     Nginx tags git release as in `release-1.2.3`
-    This removes the the `release-` prefix.
+    This removes the `release-` prefix.
 
     For example:
     >>> clean_nginx_git_tag("release-1.2.3") == "1.2.3"

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -583,7 +583,7 @@ Here is your API key:
 
    Token {auth_token}
 
-If you did NOT request this API key, you can either ignore this email or contact us at support@nexb.com and let us know in the forward that you did not request an API key.
+If you did NOT request this API key, you can either ignore this email or contact us at support@nexb.com and let us know in the future that you did not request an API key.
 
 The API root is at https://public.vulnerablecode.io/api
 To learn more about using the VulnerableCode.io API, please refer to the live API documentation at https://public.vulnerablecode.io/api/docs


### PR DESCRIPTION
## Summary
  Spelling typos found using [`codespell`](https://github.com/codespell-project/codespell) and fixed manually across 16 files (24 corrections).

  ### Scope

  - **Docs:** `CHANGELOG.rst`, `installation.rst`, `reference_importer_overview.rst`, `reference_improver_overview.rst`, `tutorial_add_importer_pipeline.rst`,  
  `tutorial_add_improver_pipeline.rst`
  - **Source:** `federated/README.rst`, `federated/__init__.py`, `import_runner.py`, `improve_runner.py`, `models.py`, `pipelines/nvd_importer.py`,
  `pipelines/v2_importers/nvd_importer.py`, `utils.py`, `views.py`
  - **Tests:** `test_nginx_importer_pipeline.py`

  All changes are limited to comments, docstrings, documentation, and one local test variable rename. No functional code changes.

  Full list of corrections: https://github.com/aboutcode-org/vulnerablecode/issues/2134

  Fixes https://github.com/aboutcode-org/vulnerablecode/issues/2134

  Signed-off-by: Mrityunjay Raj <mr.raj.earth@gmail.com>