### PR TITLE
Fix GentooImporter InvalidVersion error by stripping slots

### DIFF
--- a/vulnerabilities/importers/gentoo.py
+++ b/vulnerabilities/importers/gentoo.py
@@ -104,11 +104,15 @@ class GentooImporter(Importer):
             safe_versions, affected_versions = GentooImporter.get_safe_and_affected_versions(pkg)
 
             for version in safe_versions:
+                # version can have a slot, which we don't support in univers
+                version = version.split(":")[0]
                 constraints.append(
                     VersionConstraint(version=GentooVersion(version), comparator="=").invert()
                 )
 
             for version in affected_versions:
+                # version can have a slot, which we don't support in univers
+                version = version.split(":")[0]
                 constraints.append(
                     VersionConstraint(version=GentooVersion(version), comparator="=")
                 )


### PR DESCRIPTION
Problem
The 
GentooImporter
 was failing with univers.versions.InvalidVersion errors when encountering package versions containing slots (e.g., '3.24.48:3'). This happened because univers.versions.GentooVersion does not support the slot syntax in the version string.

Fixes #1921

Solution
Updated 
vulnerabilities/importers/gentoo.py
 to strip the slot suffix (starting with :) from version strings before passing them to GentooVersion. This ensures that only the version number is used for comparison, avoiding the validation error.

Changes
Modified GentooImporter.affected_and_safe_purls to split version strings on : and take the first part.
Verification