### PR TITLE
Resolve SyntaxWarning in Fireeye Importer

### DIFF
--- a/vulnerabilities/importers/fireeye.py
+++ b/vulnerabilities/importers/fireeye.py
@@ -112,7 +112,7 @@ def matcher_url(ref) -> str:
     """
     Returns URL of the reference markup from reference url in Markdown format
     """
-    markup_regex = "\[([^\[]+)]\(\s*(http[s]?://.+)\s*\)"
+    markup_regex = r"\[([^\[]+)]\(\s*(http[s]?://.+)\s*\)"
     matched_markup = re.findall(markup_regex, ref)
     if matched_markup:
         return matched_markup[0][1]

--- a/vulnerabilities/pipelines/v2_importers/fireeye_importer_v2.py
+++ b/vulnerabilities/pipelines/v2_importers/fireeye_importer_v2.py
@@ -154,7 +154,7 @@ def matcher_url(ref) -> str:
     """
     Returns URL of the reference markup from reference url in Markdown format
     """
-    markup_regex = "\[([^\[]+)]\(\s*(http[s]?://.+)\s*\)"
+    markup_regex = r"\[([^\[]+)]\(\s*(http[s]?://.+)\s*\)"
     matched_markup = re.findall(markup_regex, ref)
     if matched_markup:
         return matched_markup[0][1]


### PR DESCRIPTION
Python 3.12 has upgraded "invalid escape sequence" alerts from a DeprecationWarning to a SyntaxWarning
this is why we see this warning .

> Python 3.12 [upgraded the DeprecationWarning to a SyntaxWarning](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes) 

https://stackoverflow.com/a/77531416/9871531

Issue:
- https://github.com/aboutcode-org/vulnerablecode/issues/2177
