### PR TITLE
feat: add EPSS history storage and trend chart visualization

### DIFF
--- a/vulnerabilities/templates/vulnerability_details.html
+++ b/vulnerabilities/templates/vulnerability_details.html
@@ -152,6 +152,20 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                                     {{ vulnerability.risk_score }}
                                 </td>
                             </tr>
+                            {% if epss_data %}
+                            <tr>
+                                <td class="two-col-left">
+                                    <span class="has-tooltip-multiline has-tooltip-black has-tooltip-arrow has-tooltip-text-left"
+                                          data-tooltip="The EPSS score represents the probability [0-1] of exploitation in the wild in the next 30 days. Percentile indicates the proportion of all scored vulnerabilities with the same or a lower score.">
+                                        EPSS Score
+                                    </span>
+                                </td>
+                                <td class="two-col-right wrap-strings">
+                                    {{ epss_data.score }}
+                                    <span class="has-text-grey ml-2">({{ epss_data.percentile }} percentile)</span>
+                                </td>
+                            </tr>
+                            {% endif %}
                             <tr>
                                 <td class="two-col-left"
                                     data-tooltip="Risk expressed as a number ranging from 0 to 10. It is calculated by multiplying
@@ -502,7 +516,7 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                     {% endfor %}
             </div>
 
-        
+
             <div class="tab-div content" data-content="epss">
                 {% if epss_data %}
                     <div class="has-text-weight-bold tab-nested-div ml-1 mb-1 mt-1">
@@ -541,6 +555,14 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
                             {% endif %}
                         </tbody>
                     </table>
+
+                    <div class="has-text-weight-bold tab-nested-div ml-1 mb-1 mt-4">
+                        EPSS Score Trend
+                    </div>
+                    <div style="max-width: 800px; margin-top: 1rem;">
+                        <canvas id="epssChart"></canvas>
+                    </div>
+                    <script id="epss-history-data" type="application/json">{{ epss_history_json }}</script>
                 {% else %}
                     <p>No EPSS data available for this vulnerability.</p>
                 {% endif %}
@@ -597,6 +619,58 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
 {% endif %}
 
 <script src="{% static 'js/main.js' %}" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+<script>
+    (function () {
+        var canvas = document.getElementById('epssChart');
+        if (!canvas) return;
+
+        var raw = document.getElementById('epss-history-data');
+        if (!raw) return;
+
+        var history = JSON.parse(raw.textContent || '[]');
+        if (history.length === 0) return;
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: history.map(function (e) { return e.date; }),
+                datasets: [{
+                    label: 'EPSS Score',
+                    data: history.map(function (e) { return e.score; }),
+                    borderColor: '#3273dc',
+                    backgroundColor: 'rgba(50, 115, 220, 0.08)',
+                    pointRadius: history.length > 60 ? 2 : 4,
+                    tension: 0.1,
+                    fill: true,
+                }]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        min: 0,
+                        max: 1,
+                        title: { display: true, text: 'EPSS Score (0–1)' }
+                    },
+                    x: {
+                        title: { display: true, text: 'Date' }
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            afterLabel: function (ctx) {
+                                var p = history[ctx.dataIndex].percentile;
+                                return p != null ? 'Percentile: ' + p : '';
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    })();
+</script>
 
 <script>
     function goToTab(tabName) {

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -6,6 +6,7 @@
 # See https://github.com/aboutcode-org/vulnerablecode for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
+import json
 import logging
 
 from cvss.exceptions import CVSS2MalformedError
@@ -386,14 +387,29 @@ class VulnerabilityDetails(DetailView):
             ):
                 logging.error(f"CVSSMalformedError for {severity.scoring_elements}")
 
-        epss_severity = vulnerability.severities.filter(scoring_system="epss").first()
+        epss_severities = vulnerability.severities.filter(
+            scoring_system="epss"
+        ).order_by("published_at")
+
         epss_data = None
-        if epss_severity:
+        epss_history_json = "[]"
+        if epss_severities.exists():
+            latest = epss_severities.last()
             epss_data = {
-                "percentile": epss_severity.scoring_elements,
-                "score": epss_severity.value,
-                "published_at": epss_severity.published_at,
+                "percentile": latest.scoring_elements,
+                "score": latest.value,
+                "published_at": latest.published_at,
             }
+            epss_history_json = json.dumps(
+                [
+                    {
+                        "date": e.published_at.strftime("%Y-%m-%d") if e.published_at else None,
+                        "score": float(e.value) if e.value else None,
+                        "percentile": float(e.scoring_elements) if e.scoring_elements else None,
+                    }
+                    for e in epss_severities
+                ]
+            )
 
         context.update(
             {
@@ -407,6 +423,7 @@ class VulnerabilityDetails(DetailView):
                 "status": vulnerability.get_status_label,
                 "history": vulnerability.history,
                 "epss_data": epss_data,
+                "epss_history_json": epss_history_json,
             }
         )
         return context


### PR DESCRIPTION
## Summary

- Fetch full EPSS score history ordered by "published_at" in "VulnerabilityDetails" view instead of only the latest entry
- Serialize EPSS history as JSON and pass it safely to the template context
- Add a Chart.js line chart in the EPSS tab to visualize score changes over time (with percentile shown in tooltips)
- Add EPSS score + percentile row to the Essentials tab severity table so users can see it without switching tabs

Closes #1276
Relates to #1732

## Test plan

- [ ] Open a vulnerability page that has EPSS data
- [ ] Check the Essentials tab shows an EPSS Score row with score and percentile
- [ ] Switch to the EPSS tab and verify the current score table is still present
- [ ] Verify the trend chart renders with dates on X-axis and score (0–1) on Y-axis
- [ ] Hover over chart points to confirm percentile appears in the tooltip
- [ ] Open a vulnerability with no EPSS data and confirm no chart or errors appear