### PR TITLE
fix: run pipeline scheduling jobs in respective queues

### DIFF
--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -2351,7 +2351,11 @@ class PipelineSchedule(models.Model):
         if not self.pk:
             self.schedule_work_id = self.create_new_job(execute_now=True)
         elif self.pk and (existing := PipelineSchedule.objects.get(pk=self.pk)):
-            if existing.is_active != self.is_active or existing.run_interval != self.run_interval:
+            if (
+                existing.is_active != self.is_active
+                or existing.run_interval != self.run_interval
+                or existing.run_priority != self.run_priority
+            ):
                 self.schedule_work_id = self.create_new_job()
         self.full_clean()
         return super().save(*args, **kwargs)

--- a/vulnerabilities/schedules.py
+++ b/vulnerabilities/schedules.py
@@ -24,6 +24,7 @@ def schedule_execution(pipeline_schedule, execute_now=False):
     Takes a `PackageSchedule` object as input and schedule a
     recurring job using `rq_scheduler` to execute the pipeline.
     """
+    queue_name = pipeline_schedule.get_run_priority_display()
     first_execution = datetime.datetime.now(tz=datetime.timezone.utc)
     if not execute_now:
         first_execution = pipeline_schedule.next_run_date
@@ -36,6 +37,7 @@ def schedule_execution(pipeline_schedule, execute_now=False):
         args=[pipeline_schedule.pipeline_id],
         interval=interval_in_seconds,
         repeat=None,
+        queue_name=queue_name,
     )
     return job._id
 


### PR DESCRIPTION
Instead of running all scheduling jobs in default queue, use each pipeline's assigned queue for scheduling as well as running pipeline.