### PR TITLE
Update OSS Index datasource for Sonatype Guide

### DIFF
--- a/vulntotal/datasources/oss_index.py
+++ b/vulntotal/datasources/oss_index.py
@@ -23,17 +23,18 @@ logger = logging.getLogger(__name__)
 class OSSDataSource(DataSource):
     spdx_license_expression = "TODO"
     license_url = "TODO"
-    api_unauthenticated = "https://ossindex.sonatype.org/api/v3/component-report"
-    api_authenticated = "https://ossindex.sonatype.org/api/v3/authorized/component-report"
+    api_unauthenticated = "https://api.guide.sonatype.com/api/v3/component-report"
+    api_authenticated = "https://api.guide.sonatype.com/api/v3/authorized/component-report"
 
     def fetch_json_response(self, coordinates):
-        """Fetch JSON response from OSS Index API for a given list of coordinates.
+        """Fetch JSON response from the Sonatype Guide OSS Index compatibility API.
 
         Parameters:
             coordinates: A list of strings representing the package coordinates.
 
         Returns:
-            A dictionary containing the JSON response from the OSS Index API, or None if the response is unsuccessful or an error occurs while fetching data.
+            A dictionary containing the JSON response from the compatibility API, or None
+            if the response is unsuccessful or an error occurs while fetching data.
         """
         username = os.environ.get("OSS_USERNAME", None)
         token = os.environ.get("OSS_TOKEN", None)
@@ -91,7 +92,7 @@ class OSSDataSource(DataSource):
 
 def parse_advisory(component, purl) -> Iterable[VendorData]:
     """
-    Parse component from OSS Index API and yield VendorData.
+    Parse component from the Sonatype Guide OSS Index compatibility API and yield VendorData.
 
     Parameters:
         component: A list containing a dictionary with component details.

--- a/vulntotal/tests/test_oss_index.py
+++ b/vulntotal/tests/test_oss_index.py
@@ -9,6 +9,7 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from commoncode import testcase
 from packageurl import PackageURL
@@ -19,6 +20,41 @@ from vulntotal.datasources import oss_index
 
 class TestDeps(testcase.FileBasedTesting):
     test_data_dir = str(Path(__file__).resolve().parent / "test_data" / "oss_index")
+
+    def test_fetch_json_response_uses_sonatype_guide_compatibility_api(self):
+        coordinates = ["pkg:pypi/django@5.2.1"]
+        datasource = oss_index.OSSDataSource()
+
+        with patch.object(oss_index.requests, "post") as mock_post:
+            mock_response = mock_post.return_value
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = []
+
+            assert datasource.fetch_json_response(coordinates) == []
+
+        mock_post.assert_called_once_with(
+            "https://api.guide.sonatype.com/api/v3/component-report",
+            auth=None,
+            json={"coordinates": coordinates},
+        )
+
+    def test_fetch_json_response_uses_authenticated_sonatype_guide_compatibility_api(self):
+        coordinates = ["pkg:pypi/django@5.2.1"]
+        datasource = oss_index.OSSDataSource()
+
+        with patch.dict(oss_index.os.environ, {"OSS_USERNAME": "user", "OSS_TOKEN": "token"}):
+            with patch.object(oss_index.requests, "post") as mock_post:
+                mock_response = mock_post.return_value
+                mock_response.raise_for_status.return_value = None
+                mock_response.json.return_value = []
+
+                assert datasource.fetch_json_response(coordinates) == []
+
+        mock_post.assert_called_once_with(
+            "https://api.guide.sonatype.com/api/v3/authorized/component-report",
+            auth=("user", "token"),
+            json={"coordinates": coordinates},
+        )
 
     def test_parse_advisory(self):
         advisory_file = self.get_test_loc("advisory.json")


### PR DESCRIPTION
Closes #2311.

Summary:
- Point the OSS Index datasource at Sonatype Guide compatibility API endpoints.
- Keep the existing OSS Index-compatible request/response parsing behavior.
- Add focused no-network tests for unauthenticated and authenticated endpoint selection.

Validation:
- .venv/bin/python -m pytest vulntotal/tests/test_oss_index.py -q (3 passed; local Python 3.14 required pytest 9.0.3 because repo-pinned pytest 7.1.1 errors before collection on Python 3.14)
- .venv/bin/python -m black --check vulntotal/datasources/oss_index.py vulntotal/tests/test_oss_index.py
- .venv/bin/python -m isort --check-only vulntotal/datasources/oss_index.py vulntotal/tests/test_oss_index.py
- git diff --check
- git diff --cached --check
- git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1
- git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1

Limitations:
- Full make test was not run locally; this was validated with a minimal focused virtualenv on Python 3.14.