### PR TITLE
Prepare for release v40.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Release notes
 =============
 
+Version v40.0.1
+---------------------
+
+- Add throttling info in API docs, remove V1 and V2 API docs.
+- Avoid converting None to "None" in AdvisorySeverity.
+- Refine package curation workflow.
+
+
 Version v40.0.0
 ---------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vulnerablecode
-version = 40.0.0
+version = 40.0.1
 license = Apache-2.0 AND CC-BY-SA-4.0
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390

--- a/vulnerablecode/__init__.py
+++ b/vulnerablecode/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import git
 
-__version__ = "40.0.0"
+__version__ = "40.0.1"
 
 
 PROJECT_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
This release add docs, and avoid converting None to "None" in AdvisorySeverity, refine package curation workflow.