### PR TITLE
fix: Gentoo GLSA data embeds the package SLOT directly in the version

### DIFF
--- a/vulnerabilities/importers/gentoo.py
+++ b/vulnerabilities/importers/gentoo.py
@@ -144,6 +144,12 @@ class GentooImporter(Importer):
                 if len(info.attrib.get("range")) > 2:
                     continue
 
+            # GLSA data sometimes appends the SLOT to the version using a
+            # colon, e.g. "6.9.3:6" for a package in SLOT "6". A colon is not
+            # part of the Gentoo version syntax, so it must be stripped
+            # before the value can be parsed as a GentooVersion.
+            version = info.text.partition(":")[0]
+
             if info.tag == "unaffected":
                 # quick hack, to know whether this
                 # version lies in this range, 'e' stands for
@@ -153,14 +159,14 @@ class GentooImporter(Importer):
                 # which ('rle', 'rge', 'rgt') are ignored, because they compare
                 # 'release' not the 'version'.
                 if "e" in info.attrib["range"]:
-                    safe_versions.add(info.text)
+                    safe_versions.add(version)
                 else:
-                    affected_versions.add(info.text)
+                    affected_versions.add(version)
 
             elif info.tag == "vulnerable":
                 if "e" in info.attrib["range"]:
-                    affected_versions.add(info.text)
+                    affected_versions.add(version)
                 else:
-                    safe_versions.add(info.text)
+                    safe_versions.add(version)
 
         return safe_versions, affected_versions

--- a/vulnerabilities/pipelines/v2_importers/gentoo_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/gentoo_importer.py
@@ -185,4 +185,9 @@ def get_affected_and_fixed_purls(affected_elem, logger):
 
             qualifiers = {"slot": slot_value} if slot_value else {}
             purl = PackageURL(type="ebuild", name=pkg_name, namespace=pkg_ns, qualifiers=qualifiers)
-            yield purl, (comparator, info.text), (info.tag == "unaffected")
+            # GLSA data sometimes appends the SLOT to the version using a
+            # colon, e.g. "6.9.3:6" for a package in SLOT "6". A colon is not
+            # part of the Gentoo version syntax, so it must be stripped
+            # before the value can be parsed as a GentooVersion.
+            version = info.text.partition(":")[0]
+            yield purl, (comparator, version), (info.tag == "unaffected")

--- a/vulnerabilities/tests/pipelines/v2_importers/test_gentoo_importer_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_gentoo_importer_v2.py
@@ -22,6 +22,7 @@ TEST_CVE_FILES = [
     TEST_DATA / "glsa-201709-09.xml",
     TEST_DATA / "glsa-202511-02.xml",
     TEST_DATA / "glsa-202512-01.xml",
+    TEST_DATA / "glsa-202511-03.xml",
 ]
 
 

--- a/vulnerabilities/tests/test_data/gentoo/glsa-202511-03-expected.json
+++ b/vulnerabilities/tests/test_data/gentoo/glsa-202511-03-expected.json
@@ -1,0 +1,95 @@
+[
+  {
+    "aliases": [
+      "CVE-2023-45872"
+    ],
+    "summary": "Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "ebuild",
+          "namespace": "dev-qt",
+          "name": "qtsvg",
+          "version": "",
+          "qualifiers": "",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:ebuild/!=6.9.3",
+        "fixed_version": null
+      }
+    ],
+    "references": [
+      {
+        "reference_id": "GLSA-202511-03",
+        "reference_type": "",
+        "url": "https://security.gentoo.org/glsa/202511-03",
+        "severities": []
+      }
+    ],
+    "date_published": null,
+    "weaknesses": [],
+    "url": "https://security.gentoo.org/glsa/202511-03"
+  },
+  {
+    "aliases": [
+      "CVE-2025-10728"
+    ],
+    "summary": "Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "ebuild",
+          "namespace": "dev-qt",
+          "name": "qtsvg",
+          "version": "",
+          "qualifiers": "",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:ebuild/!=6.9.3",
+        "fixed_version": null
+      }
+    ],
+    "references": [
+      {
+        "reference_id": "GLSA-202511-03",
+        "reference_type": "",
+        "url": "https://security.gentoo.org/glsa/202511-03",
+        "severities": []
+      }
+    ],
+    "date_published": null,
+    "weaknesses": [],
+    "url": "https://security.gentoo.org/glsa/202511-03"
+  },
+  {
+    "aliases": [
+      "CVE-2025-10729"
+    ],
+    "summary": "Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "ebuild",
+          "namespace": "dev-qt",
+          "name": "qtsvg",
+          "version": "",
+          "qualifiers": "",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:ebuild/!=6.9.3",
+        "fixed_version": null
+      }
+    ],
+    "references": [
+      {
+        "reference_id": "GLSA-202511-03",
+        "reference_type": "",
+        "url": "https://security.gentoo.org/glsa/202511-03",
+        "severities": []
+      }
+    ],
+    "date_published": null,
+    "weaknesses": [],
+    "url": "https://security.gentoo.org/glsa/202511-03"
+  }
+]

--- a/vulnerabilities/tests/test_data/gentoo/glsa-202511-03.xml
+++ b/vulnerabilities/tests/test_data/gentoo/glsa-202511-03.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glsa SYSTEM "http://www.gentoo.org/dtd/glsa.dtd">
+<glsa id="202511-03">
+    <title>qtsvg: Multiple Vulnerabilities</title>
+    <synopsis>Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.</synopsis>
+    <product type="ebuild">qtsvg</product>
+    <announced>2025-11-24</announced>
+    <revised count="1">2025-11-24</revised>
+    <bug>915998</bug>
+    <bug>963710</bug>
+    <access>local and remote</access>
+    <affected>
+        <package name="dev-qt/qtsvg" auto="yes" arch="*">
+            <unaffected range="ge">6.9.3:6</unaffected>
+            <vulnerable range="lt">6.9.3:6</vulnerable>
+        </package>
+    </affected>
+    <background>
+        <p>qtsvg is a SVG rendering library for the Qt framework.</p>
+    </background>
+    <description>
+        <p>Multiple vulnerabilities have been discovered in qtsvg. Please review the CVE identifiers referenced below for details.</p>
+    </description>
+    <impact type="high">
+        <p>Please review the referenced CVE identifiers for details.</p>
+    </impact>
+    <workaround>
+        <p>There is no known workaround at this time.</p>
+    </workaround>
+    <resolution>
+        <p>All qtsvg users should upgrade to the latest version:</p>
+        
+        <code>
+          # emerge --sync
+          # emerge --ask --oneshot --verbose ">=dev-qt/qtsvg-6.9.3"
+        </code>
+    </resolution>
+    <references>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2023-45872">CVE-2023-45872</uri>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2025-10728">CVE-2025-10728</uri>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2025-10729">CVE-2025-10729</uri>
+    </references>
+    <metadata tag="requester" timestamp="2025-11-24T23:58:02.219156Z">graaff</metadata>
+    <metadata tag="submitter" timestamp="2025-11-24T23:58:02.221875Z">sam</metadata>
+</glsa>

--- a/vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03-expected.json
+++ b/vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03-expected.json
@@ -1,0 +1,59 @@
+[
+  {
+    "advisory_id": "GLSA-202511-03",
+    "aliases": [
+      "CVE-2023-45872",
+      "CVE-2025-10728",
+      "CVE-2025-10729"
+    ],
+    "summary": "Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.",
+    "affected_packages": [
+      {
+        "package": {
+          "type": "ebuild",
+          "namespace": "dev-qt",
+          "name": "qtsvg",
+          "version": "",
+          "qualifiers": "",
+          "subpath": ""
+        },
+        "affected_version_range": "vers:ebuild/<6.9.3",
+        "fixed_version_range": null,
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      },
+      {
+        "package": {
+          "type": "ebuild",
+          "namespace": "dev-qt",
+          "name": "qtsvg",
+          "version": "",
+          "qualifiers": "",
+          "subpath": ""
+        },
+        "affected_version_range": null,
+        "fixed_version_range": "vers:ebuild/>=6.9.3",
+        "introduced_by_commit_patches": [],
+        "fixed_by_commit_patches": []
+      }
+    ],
+    "references": [
+      {
+        "reference_id": "GLSA-202511-03",
+        "reference_type": "",
+        "url": "https://security.gentoo.org/glsa/202511-03"
+      }
+    ],
+    "patches": [],
+    "severities": [
+      {
+        "system": "generic_textual",
+        "value": "high",
+        "scoring_elements": ""
+      }
+    ],
+    "date_published": null,
+    "weaknesses": [],
+    "url": "https://security.gentoo.org/glsa/202511-03"
+  }
+]

--- a/vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03.xml
+++ b/vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glsa SYSTEM "http://www.gentoo.org/dtd/glsa.dtd">
+<glsa id="202511-03">
+    <title>qtsvg: Multiple Vulnerabilities</title>
+    <synopsis>Multiple vulnerabilities have been discovered in qtsvg, the worst of which could lead to execution of arbitrary code.</synopsis>
+    <product type="ebuild">qtsvg</product>
+    <announced>2025-11-24</announced>
+    <revised count="1">2025-11-24</revised>
+    <bug>915998</bug>
+    <bug>963710</bug>
+    <access>local and remote</access>
+    <affected>
+        <package name="dev-qt/qtsvg" auto="yes" arch="*">
+            <unaffected range="ge">6.9.3:6</unaffected>
+            <vulnerable range="lt">6.9.3:6</vulnerable>
+        </package>
+    </affected>
+    <background>
+        <p>qtsvg is a SVG rendering library for the Qt framework.</p>
+    </background>
+    <description>
+        <p>Multiple vulnerabilities have been discovered in qtsvg. Please review the CVE identifiers referenced below for details.</p>
+    </description>
+    <impact type="high">
+        <p>Please review the referenced CVE identifiers for details.</p>
+    </impact>
+    <workaround>
+        <p>There is no known workaround at this time.</p>
+    </workaround>
+    <resolution>
+        <p>All qtsvg users should upgrade to the latest version:</p>
+        
+        <code>
+          # emerge --sync
+          # emerge --ask --oneshot --verbose ">=dev-qt/qtsvg-6.9.3"
+        </code>
+    </resolution>
+    <references>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2023-45872">CVE-2023-45872</uri>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2025-10728">CVE-2025-10728</uri>
+        <uri link="https://nvd.nist.gov/vuln/detail/CVE-2025-10729">CVE-2025-10729</uri>
+    </references>
+    <metadata tag="requester" timestamp="2025-11-24T23:58:02.219156Z">graaff</metadata>
+    <metadata tag="submitter" timestamp="2025-11-24T23:58:02.221875Z">sam</metadata>
+</glsa>

--- a/vulnerabilities/tests/test_gentoo.py
+++ b/vulnerabilities/tests/test_gentoo.py
@@ -32,3 +32,14 @@ def test_gentoo_import():
     result = [adv.to_dict() for adv in advisories]
     expected_file = os.path.join(TEST_DIR, "gentoo-expected.json")
     util_tests.check_results_against_json(result, expected_file)
+
+
+def test_gentoo_import_version_with_slot():
+    # See https://github.com/aboutcode-org/vulnerablecode/issues/1921
+    # GLSA data can append the SLOT to a version using a colon, e.g.
+    # "6.9.3:6", which is not valid Gentoo version syntax on its own.
+    file = os.path.join(TEST_DIR, "glsa-202511-03.xml")
+    advisories = GentooImporter().process_file(file)
+    result = [adv.to_dict() for adv in advisories]
+    expected_file = os.path.join(TEST_DIR, "glsa-202511-03-expected.json")
+    util_tests.check_results_against_json(result, expected_file)


### PR DESCRIPTION
Fixes #1921

## Summary
Gentoo GLSA data embeds the package SLOT directly in the version text (e.g. '6.9.3:6' or '3.24.48:3'), which univers.versions.GentooVersion cannot parse since a colon isn't valid Gentoo version syntax; this caused affected/safe versions to be silently dropped (previously caught by an existing try/except, masking the real bug of empty affected_packages). Fixed both the legacy and v2 Gentoo importers to strip the ':<slot>' suffix before constructing GentooVersion, and added regression tests using a real GLSA (qtsvg, 202511-03) fetched from the upstream glsa.git repo that reproduces the issue.

## Changes
- `vulnerabilities/importers/gentoo.py`
- `vulnerabilities/pipelines/v2_importers/gentoo_importer.py`
- `vulnerabilities/tests/test_gentoo.py`
- `vulnerabilities/tests/pipelines/v2_importers/test_gentoo_importer_v2.py`
- `vulnerabilities/tests/test_data/gentoo/glsa-202511-03.xml`
- `vulnerabilities/tests/test_data/gentoo/glsa-202511-03-expected.json`
- `vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03.xml`
- `vulnerabilities/tests/test_data/gentoo_v2/glsa-202511-03-expected.json`

## How this was tested
Ran `the affected tests` locally.
