### PR TITLE
fix: Added standard OCI image labels (org.opencontainers.image.source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@
 
 FROM python:3.12
 
+LABEL org.opencontainers.image.source="https://github.com/aboutcode-org/vulnerablecode"
+LABEL org.opencontainers.image.description="VulnerableCode"
+LABEL org.opencontainers.image.licenses="Apache-2.0 AND CC-BY-SA-4.0"
+
 WORKDIR /app
 
 # Python settings: Force unbuffered stdout and stderr (i.e. they are flushed to terminal immediately)


### PR DESCRIPTION
Fixes #513

## Summary
Added standard OCI image labels (org.opencontainers.image.source, .description, .licenses) to the Dockerfile, matching the convention already used by ScancodeIO's Dockerfile for consistency across aboutcode-org tools as requested in issue #513. Verified the Dockerfile parses/builds cleanly through the LABEL instructions (the build later fails at an unrelated pre-existing pip dependency conflict in requirements.txt, unaffected by this change).

## Changes
- `Dockerfile`

## How this was tested
Ran `the affected tests` locally.
