### PR TITLE
Do not build an empty version range in the apache_httpd importer

### DIFF
--- a/vulnerabilities/pipelines/v2_importers/apache_httpd_importer.py
+++ b/vulnerabilities/pipelines/v2_importers/apache_httpd_importer.py
@@ -347,4 +347,7 @@ class ApacheHTTPDImporterPipeline(VulnerableCodeBaseImporterPipelineV2):
                     ).invert()
                 )
 
+        if not constraints:
+            return None
+
         return ApacheVersionRange(constraints=constraints)

--- a/vulnerabilities/tests/pipelines/v2_importers/test_apache_httpd_importer_pipeline_v2.py
+++ b/vulnerabilities/tests/pipelines/v2_importers/test_apache_httpd_importer_pipeline_v2.py
@@ -163,3 +163,10 @@ def test_to_version_ranges_unknown_comparator(pipeline):
     fixed_versions = []
     with pytest.raises(ValueError):
         pipeline.to_version_ranges(versions_data, fixed_versions)
+
+
+def test_to_version_ranges_without_constraints(pipeline):
+    # A version range with no constraints serializes to "vers:apache/", which
+    # VersionRange.from_string() rejects, so no range must be returned at all.
+    versions_data = [{"version_value": "", "version_affected": "="}]
+    assert pipeline.to_version_ranges(versions_data, []) is None


### PR DESCRIPTION
Closes #2387

`ApacheHTTPDImporterPipeline.to_version_ranges()` always returned `ApacheVersionRange(constraints=constraints)`. When every candidate version is empty or ignorable the constraint list is empty and the range serializes to `vers:apache/`, which `VersionRange.from_string()` later rejects with *"specifies no version range constraints"* — so `AffectedPackage.from_dict` logs the reported traceback and drops the package. Returning `None` instead lets the existing `if affected_version_range:` guard in `to_advisory()` skip it cleanly.

Regression test `test_to_version_ranges_without_constraints` fails on the unpatched code and passes with the fix.
